### PR TITLE
Modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "dgen"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dgen"
-version = "0.1.1"
+version = "0.2.0"
 readme = "README.md"
 documentation = "https://github.com/psFried/dgen#dgen"
 description = "An interpreted DSL for generating test data in any format"

--- a/README.md
+++ b/README.md
@@ -9,20 +9,15 @@ The language documentation is pretty sparse at the moment, but this will hopeful
 
 # Example
 
-The following program will print 10 random quoted words, separated by newlines:
+The following program will print 5 random quoted words, separated by newlines:
 
 ```
-$ dgen run -p 'repeat_delimited(10, double_quote(words()), "\n")'
+$ dgen run -p 'repeat_delimited(5, double_quote(words()), "\n")'
 "gule"
 "erugation"
 "avouchment"
 "hymnless"
 "reclusory"
-"deferral"
-"debauched"
-"unenervated"
-"charkhana"
-"sheatfish"
 ```
 
 dgen programs are invoked by calling `dgen run` and providing the program input in one of several ways:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Generate evil test data
 
-dgen is a CLI tool for generating pseudorandom data in arbitrary formats. The goal is to have a tool that works equally well for both textual and binary formats. Pgen is really just an interpreter for a simple domain-specific functional language. The syntax is documented [here](SYNTAX.md).
+dgen is a CLI tool for generating pseudorandom data in arbitrary formats. The goal is to have a tool that works equally well for both textual and binary formats. Dgen is really just an interpreter for a simple domain-specific functional language. The syntax is documented [here](SYNTAX.md).
+The language documentation is pretty sparse at the moment, but this will hopefully be improved shortly. PRs are welcome!
 
 # Example
 
@@ -24,7 +25,7 @@ $ dgen run -p 'repeat_delimited(10, double_quote(words()), "\n")'
 "sheatfish"
 ```
 
-Pgen programs are invoked by calling `dgen run` and providing the program input in one of several ways:
+dgen programs are invoked by calling `dgen run` and providing the program input in one of several ways:
 
 - `-p`, `--program`: the program can be provided on the command line. This is easiest for simple expressions.
 - `-f`, `--program-file`: interpret the given file as a program. Nice for more complex programs
@@ -32,9 +33,27 @@ Pgen programs are invoked by calling `dgen run` and providing the program input 
 
 You can also add your own libraries to the program scope using the `--lib` option.
 
-PGen has a bunch of builtin functions, too. You can list the builtin functions by executing `dgen help`. You can optionally filter the list of functions by name with `pgen help --function <name>`. Of course `pgen -h` will print out info on all of the available options.
+`dgen file1 file2 fileN` can also be used as a shortcut for `dgen run --lib file1 --lib file2 -f fileN`. This allows you to run an executable dgen script by simply putting a shebang (`#!dgen`) at the top of the file.
+
+dGen has a bunch of builtin functions, too. You can list the builtin functions by executing `dgen help`. You can optionally filter the list of functions by name with `dgen help --function <name>`. Of course `dgen -h` will print out info on all of the available options.
 
 Take a look at [the examples](dgen_examples/) for more.
+
+## Goals
+
+- Make it easy to generate files and streams of data for testing
+- Make it easy to share and re-use programs for data generation
+- Make it easy to test data that can be represented in multiple ways
+- Easily integrate with various testing tools and workflows
+
+## Non-Goals
+
+- Be a general purpose language. Currently the language is not even turing-complete, and it's not really clear that there would be any benefit to turing-completeness.
+- Understand the samantics of your data. DGen is more focused on how data is _represented_ rather than what it _means_.
+
+# What's differnt about dgen?
+
+DGen focuses on how data is _represented_. Take JSON for example. It's easy to find random data generators that will output the data as well formed JSON. But if you're testing a JSON parser, then you want to use JSON with different and inconsistent formatting! Like many other formats, JSON has many _valid_ ways to represent the same data. You might want to test keys that are sometimes surrounded with double-quotes and sometimes single-quotes or unquoted. DGen is meant to fill this gap in between a well-formed dataset generator (which will typically always produce consistently formatted representations) and a fuzz tester (which is more useful for testing _invalid_ input).
 
 ### Build
 

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -1,24 +1,28 @@
 # PGen Syntax
 
-The PGen language syntax is intentionally as simple and minimal as possible. Most people will probably only write dgen scripts occasionally, so we want the syntax to be simple and easy to remember. As of right now, the language only has a few types.
+The PGen language syntax is intentionally as simple and minimal as possible. Most people will probably only write dgen scripts occasionally, so we want the syntax to be simple and easy to remember. As of right now, the language only has a few types. The grammar of dgen is broken down to function definitions and expressions. 
+
+## Comments
+The comment character is `#`. Everything after a `#` until the end of the line will be ignored by the interpreter.
 
 ## Expressions
 
-Expressions are the bread and butter of any dgen program. Expressions evaluate to something that will generate data. The simplest expressions are literals, which will always return the same constant value. By using functions, it's easy to generate pseudorandom data. Expressions come in only two flavors: literals and function calls.
+Expressions are the bread and butter of any dgen program. All expressions evaluate to a "generator" that can repeatedly generate (sometimes random) data. The simplest expressions are literals, which will always return the same constant value. By using functions, it's easy to generate pseudorandom data. Expressions come in only two flavors: literals and function calls.
 
 ### Literals
 
 Literals are the simplest type of expression there is. Each literal represents a constant expression that will always return the same value. The types of literal expressions are:
 
 - Boolean: either `true` or `false`
-- Uint: An unsigned integer value, for example `123` or `0`
-- Int: A signed integer value, for example `-4` or `+789`
-- String: Any valid sequence of unicode code points, surrounded by double quote characters. Example, "foo" or "hello world!".
+- Uint: An unsigned 65 bit integer value, for example `123` or `0`
+- Int: A signed 64 bit integer value, for example `-4` or `+789`. A signed int literal must always have the sign present, even for positive numbers.
+- Char: A 32 bit unicode codepoint expressed as a single written character between two single-quotes, for example `'a'` or `'#'`
+- String: Any valid sequence of unicode code points, surrounded by double quote characters. Example, `"foo"` or `"hello world!"`. See the notes below on Strings and Chars for more information and examples.
+- Bin: A sequence of comma-separated bytes (can either by in hex or decimal notation) between two square braces, for example: `[0x04, 0xAA]` or `[]` or `[1, 2, 3]`
 
 ### Function calls
 
-A function call takes the form of `function_name(argument1, argument2, ..., argumentN)`. Functions that take no arguments are called with empty parenstheses. For example, to generate random unsigned integers, you can call the `uint()` function. Alternatively, to generate random unsigned integers within a given range, you can call `uint(7, 33)`. 
-
+A function call takes the form of `function_name(argument1, argument2, ..., argumentN)`. For example, to generate random unsigned integers, you can call the `uint()` function. Alternatively, to generate random unsigned integers within a given range, you can call `uint(7, 33)`. The concept of flat map is also built into the dgen language as a first class citizen. Any function call may optionally include a flat mapping expression by using the syntax: `function_name(arg1, ..., argn) { value ->  <Expression> }`. Within the mapper body, `value` will always refer to the same exact value.
 
 Expressions can be arbitrarily nested. For example, to generate random alphanumeric strings or varying lengths with double quotes around them, you could use `double_quote(alphanumeric_string(uint(3, 40)))`. This will generate strings between 3 and 40 characters long and put quotes around them.
 
@@ -27,9 +31,9 @@ Expressions can be arbitrarily nested. For example, to generate random alphanume
 You can also define your own functions. Function definitions take the following form:
 `def function_name(argument1_name: <Type>, argument2_name: <Type>, ..., argumentN_name: <Type>) = <Expression>;`
 
-There's kind of a lot there, so let's break it down. First, all function definitions start with the keyword `def`, followed by at least one whitespace character. Then comes the function name. This is of course the name that will be used later when calling the function. After the name comes the names and types of the arguments. `<Type>` can be one of: `Boolean`, `Uint`, `Int`, `Float`, `Char`, or `String`. Functions that take no arguments are also valid, and just have an empty set of parentheses. After the argument list comes a single equals sign (`=`), followed by any expression. Within the body of the function, arguments can be used by calling them as functions that take no arguments. Within the body of a function, you may omit parentheses for using any arguments that were passed to your function. The end of a function definition is terminated by a mandatory semicolon (`;`).
+There's kind of a lot there, so let's break it down. First, all function definitions start with the keyword `def`, followed by at least one whitespace character. Then comes the function name. This is of course the name that will be used later when calling the function. After the name comes the names and types of the arguments. `<Type>` can be one of: `Boolean`, `Uint`, `Int`, `Float`, `Bin`, `Char`, or `String`. Functions that take no arguments are also valid, and just have an empty set of parentheses. After the argument list comes a single equals sign (`=`), followed by any expression. Within the body of the function, arguments can be used either by referencing their names directly (without parentheses) or calling them as functions that take no arguments. Within the body of a function, you may omit parentheses for using any arguments that were passed to your function. The end of a function definition is terminated by a mandatory semicolon (`;`).
 
-### User defined function example
+### Function Examples
 
 Let's create a function that repeats the string `Hello World!` a given number of times. To do this, we'll use the builtin `repeat` function.
 
@@ -40,24 +44,35 @@ Let's create a function that repeats the string `Hello World!` a given number of
 def hello_world(min_repeats: Uint, max_repeats: Uint) = 
     repeat(uint(min_repeats, max_repeats), trailing_newline("Hello World!"));
 
-
-# Calling the function
+# Calling the function will produce 4-7 lines of the text: "Hello World!"
 hello_world(4, 7)
 ```
 
-Notice that the example also contains comments, which begin with a `#` character.
+Here's some other examples of defining and calling functions. The following dgen program will print a series of lines like the following: `4 foos: foofoofoofoo`
+```
+# A simple function that always returns the string `"foo"`
+def foo() = "foo";
+
+# Repeats the string `"foo"` the given number of times
+def repeat_foo(times: Uint) = repeat(times, foo());
+
+# Makes one line of output
+def make_line(num_foos: Uint) = num_foos() {foo_count ->
+    concat(to_string(foo_count), " ", foo(), "s: ", repeat_foo(foo_count), "\n")
+};
+```
 
 ## Mapped Functions
 
-Any function may optionally use a mapper by using the syntax:
+The concept of a `flatMap` is ubuiquitous in functional programming, and the dgen language supports flat map as a first class language feature. The basic idea is that you take the value from one generator and use it create another generator. Any function call may optionally use a mapper by using the syntax:
 
 ```
-function_name(arg1, ..., argn) { mapper_argument ->
+<function_name>(<arguments*>) { <value> ->
     <Expression>
 }
 ```
 
-In a mapped function, the value of the mapper argument will always be the same within the scope of the curly braces. This allows you to reuse the same value in multiple places instead of always generating a new one. For example, the following expression will print the an unsigned integer followed by a string of that length:
+In a mapped function, the `<value>` will always be the same within the scope of the curly braces. This allows you to reuse the same value in multiple places instead of always generating a new one. For example, the following expression will print the an unsigned integer followed by a string of that length:
 
 ```
 uint(1, 10) { string_length ->
@@ -68,9 +83,59 @@ uint(1, 10) { string_length ->
 Mapped functions can be used anywhere a function is called, including in the body of function definitions. For example, the following program is equivalent to the previous one:
 
 ```
+# extract the above expression into a function
 def my_string(len: Uint) = len() { string_length ->
     concat("printing a string with ", to_string(string_length), " ascii characters: ", alphanumeric_string(string_length))
 };
 
+# calling the function
 my_string(uint(1, 10))
 ```
+
+## Notes on Strings and Chars
+
+Strings are one of the most important and complex parts of any programming language, and dgen is no exception. Strings in dgen can contain any valid sequence of unicode codepoints. Both String and Char literals can contain any unicode characters. These can either be written directly inline like `"...💩..."`, or as unidode escape sequences such as `"\U{1F4A9}"`. For a Char literal, it would look like: `'\U{1F4A9}'`. Both String and Char literals support the same escape sequences:
+
+- `\n` for a newline
+- `\r` for a carriage return
+- `\t` for a tab character
+- `\\` for a literal slash character
+- `\u{XXXX}` can be used to insert an arbitrary unicode codepoint specified by the given hexidecimal. Neither the `u` nor the hex string are case sensitive. `\u{1F4A9}` and `\U{1f4a9}` are both equivalent.
+
+# Modules
+
+Each file executed by dgen is a separate module. The name of the module is the filename, minus the `.dgen` extension if one is present. Thus passing the argument `--lib foo.dgen` will result in a module named `foo` being added to the scope. Functions defined in any module may be called from any other module by using it's name directly. Take the following example:
+
+First file
+```
+# in foo.dgen
+
+def double(string: String) = string() { value ->
+    concat(value, value)
+};
+```
+
+Second file
+```
+# in bar.dgen
+
+def double(string: String) = concat("Two times the ", string, "!");
+```
+
+When you run `dgen run --lib foo.dgen --lib bar.dgen -p 'double("wat?")'` you'll get the following error:
+```
+Error: Compilation Error: Ambiguous function call, which could refer to multiple functions:
+Called function: double(String)
+Option A: double(String) - at foo.dgen:1
+Option B: double(String) - at bar.dgen:1
+
+<command line input>:1
+
+line    1| double("wat?")
+```
+
+Within a module, it is an error to define multiple multiple functions with the same signature, but there are no restrictions on functions that are defined in separate modules. To make it clear which function you meant to call, you can always add the module name to the beginning of the function call, like `foo.double("wat?")` or `bar.double("wat?")`. If you are calling a function from the same file it's defined in, then you never need to use the module name to disambiguate it.
+
+# More Examples
+
+More examples can be found in the [degn_examples](dgen_examples) directory. 

--- a/dgen_examples/json/json.pgen
+++ b/dgen_examples/json/json.pgen
@@ -1,3 +1,4 @@
+#!dgen
 # This file is runnable as it is since it ends with an expression.
 # Running this will generate a random json object or array
 # To run this, execute: `pgen run -f pgen_examples/json/json.pgen`
@@ -9,7 +10,7 @@ def json_number() = select(
 );
 
 # generates random double quoted strings
-def json_string() = double_quote(alphanumeric_string(uint(0, 50)));
+def json_string() = single_or_double_quote(alphanumeric_string(uint(0, 50)));
 
 # generates either a string or a number
 def string_or_number() = select(json_string(), json_number());
@@ -17,8 +18,20 @@ def string_or_number() = select(json_string(), json_number());
 # generates either a string or a number, and continues to always generate that same type (but with different values)
 def stable_string_or_number() = stable_select(json_string(), json_number());
 
-# creates a random double quoted string to use as a key
-def json_key() = double_quote(alphanumeric_string(uint(2, 20)));
+# Surrounds the given string with either single or double quotes 
+def single_or_double_quote(value: String) = select(
+    double_quote(value),
+    surround(value, "'")
+);
+
+# creates a random string to use as a key. It may be surrounded by either single or double quotes, or remain unquoted
+def json_key() = select(
+    single_or_double_quote(alphanumeric_string(uint(1, 20))),
+    concat( # unquoted json keys must start with either a letter or an underscore
+        select(uppercase_ascii_string(1), lowercase_ascii_string(1), "_"),
+        alphanumeric_string(uint(0, 19))
+    )
+);
 
 # formats a json array, using whatever function is passed in the generate the values
 def json_array(value: String) = repeat_delimited(

--- a/dgen_libs/std/chars.dgen
+++ b/dgen_libs/std/chars.dgen
@@ -1,12 +1,12 @@
 
 # Generates a random character representing the ascii digits 0-9
-def digit_char() = char(48, 58);
+def digit_char() = char(48, 57);
 
 # Generates a random lowercase character in the range a-z
-def lowercase_ascii_char() = char(97, 123);
+def lowercase_ascii_char() = char(97, 122);
 
 # Generates a random uppercase character in the range A-Z
-def uppercase_ascii_char() = char(65, 91);
+def uppercase_ascii_char() = char(65, 90);
 
 # Generates a random ascii alphanumeric character
 def ascii_alphanumeric_char() = select(lowercase_ascii_char(), uppercase_ascii_char(), digit_char());

--- a/src/builtins/bin_length.rs
+++ b/src/builtins/bin_length.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use std::rc::Rc;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
-    DynBinFun, FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    DynBinFun, GenType, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -28,14 +28,14 @@ fn create_bin_len(args: Arguments) -> CreateFunctionResult {
     Ok(AnyFunction::Uint(Rc::new(BinLength(bin))))
 }
 
-pub const BIN_LENGTH: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const BIN_LENGTH: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
     function_name: "bin_length",
     description:
         "returns the length of the given binary as a Uint. Mostly useful in mapped functions",
     arguments: &[("binary", GenType::Bin)],
     variadic: false,
     create_fn: &create_bin_len,
-});
+};
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/byte_order.rs
+++ b/src/builtins/byte_order.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynFun,
-    FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    GenType, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -61,13 +61,13 @@ macro_rules! make_num_to_binary {
         impl_runnable_function!($num_type, LittleEndian, $write_le_path);
         impl_runnable_function!($num_type, BigEndian, $write_be_path);
 
-        pub const $le_builtin_name: &FunctionPrototype =  {
+        pub const $le_builtin_name: &BuiltinFunctionPrototype =  {
             fn create_le(args: Arguments) -> CreateFunctionResult {
                 let num = args.required_arg(ARG_NAME, 0, $convert_input)?;
                 Ok(AnyFunction::Bin(Rc::new(new_little_endian(num))))
             }
 
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+            &BuiltinFunctionPrototype {
                         function_name: LITTLE_ENDIAN_FUNCTION_NAME,
                         description: "converts the input number into binary with little endian byte order. The binary returned will always be exactly 8 bytes long",
                         arguments: &[
@@ -75,16 +75,16 @@ macro_rules! make_num_to_binary {
                         ],
                         variadic: false,
                         create_fn: &create_le,
-            })
+            }
         };
 
-        pub const $be_builtin_name: &FunctionPrototype =  {
+        pub const $be_builtin_name: &BuiltinFunctionPrototype =  {
             fn create_be(args: Arguments) -> CreateFunctionResult {
                 let num = args.required_arg(ARG_NAME, 0, $convert_input)?;
                 Ok(AnyFunction::Bin(Rc::new(new_big_endian(num))))
             }
 
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+            &BuiltinFunctionPrototype {
                         function_name: BIG_ENDIAN_FUNCTION_NAME,
                         description: "converts the input number into binary with big endian byte order. The binary returned will always be exactly 8 bytes long",
                         arguments: &[
@@ -92,7 +92,7 @@ macro_rules! make_num_to_binary {
                         ],
                         variadic: false,
                         create_fn: &create_be,
-            })
+            }
         };
     };
 }

--- a/src/builtins/chars.rs
+++ b/src/builtins/chars.rs
@@ -8,18 +8,18 @@ use ::{
 #[derive(Debug)]
 struct CharGenerator {
     min_inclusive: DynUintFun,
-    max_exclusive: DynUintFun,
+    max_inclusive: DynUintFun,
 }
 
 impl RunnableFunction<char> for CharGenerator {
     fn gen_value(&self, context: &mut ProgramContext) -> Result<char, Error> {
         let min = self.min_inclusive.gen_value(context)?;
-        let max = self.max_exclusive.gen_value(context)?;
+        let max = self.max_inclusive.gen_value(context)?;
 
-        let as_u64 = context.gen_range(min, max);
+        let as_u64 = context.gen_range_inclusive(min, max);
 
         ::std::char::from_u32(as_u64 as u32).ok_or_else(|| {
-            format_err!("Invalid unicode codepoint: {}, generated from range: min_inclusive: {}, max_exclusive: {}", as_u64, min, max)
+            format_err!("Invalid unicode codepoint: {}, generated from range: min_inclusive: {}, max_inclusive: {}", as_u64, min, max)
         })
     }
 
@@ -45,7 +45,7 @@ fn create_char_gen(args: Arguments) -> CreateFunctionResult {
 
     Ok(AnyFunction::Char(Rc::new(CharGenerator {
         min_inclusive: min,
-        max_exclusive: max
+        max_inclusive: max
     })))
 }
 

--- a/src/builtins/chars.rs
+++ b/src/builtins/chars.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use std::rc::Rc;
 use ::{
-    AnyFunction, BuiltinFunctionPrototype, FunctionPrototype, CreateFunctionResult, DataGenOutput, DynUintFun,
+    AnyFunction, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynUintFun,
     ProgramContext, RunnableFunction, GenType, Arguments
 };
 
@@ -49,10 +49,10 @@ fn create_char_gen(args: Arguments) -> CreateFunctionResult {
     })))
 }
 
-pub const CHAR_GEN_BUILTIN: &'static FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const CHAR_GEN_BUILTIN: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
     function_name: "char",
     description: "selects a single random character from within the provided range of unicode codepoints",
     arguments: &[(MIN_ARG, GenType::Uint), (MAX_ARG, GenType::Uint)],
     variadic: false,
     create_fn: &create_char_gen,
-});
+};

--- a/src/builtins/concat.rs
+++ b/src/builtins/concat.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use std::rc::Rc;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
-    DynBinFun, DynStringFun, FunctionPrototype, GenType, IString, ProgramContext, RunnableFunction,
+    DynBinFun, DynStringFun, GenType, IString, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -69,23 +69,24 @@ fn create_concat_bin(args: Arguments) -> CreateFunctionResult {
     let funs = args.get_required_varargs(CONCAT_ARG_NAME, 0, AnyFunction::require_bin)?;
     Ok(AnyFunction::Bin(Rc::new(Concat { funs })))
 }
-pub const CONCAT_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+
+pub const CONCAT_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "concat",
         description: "concatenates the input strings into a single output string",
         arguments: &[(CONCAT_ARG_NAME, GenType::String)],
         variadic: true,
         create_fn: &create_concat,
-    });
+    };
 
-pub const CONCAT_BIN_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const CONCAT_BIN_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "concat",
         description: "concatenates the input bytes into a single output",
         arguments: &[(CONCAT_ARG_NAME, GenType::Bin)],
         variadic: true,
         create_fn: &create_concat_bin,
-    });
+    };
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/env.rs
+++ b/src/builtins/env.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use IString;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
-    DynStringFun, FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    DynStringFun, GenType, ProgramContext, RunnableFunction,
 };
 
 fn create_env_map() -> HashMap<IString, IString> {
@@ -47,7 +47,7 @@ fn create_env(args: Arguments) -> CreateFunctionResult {
     })))
 }
 
-pub const ENV_VAR: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const ENV_VAR: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
     function_name: "env",
     description: "Returns the value of the given env variable, throws an error if the env var is not set",
     arguments: &[
@@ -55,7 +55,7 @@ pub const ENV_VAR: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunc
     ],
     variadic: false,
     create_fn: &create_env,
-});
+};
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/from_file.rs
+++ b/src/builtins/from_file.rs
@@ -8,7 +8,7 @@ use std::io::{self, Read, Seek, SeekFrom};
 use std::rc::Rc;
 use ::{
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
-    DynStringFun, FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    DynStringFun, GenType, ProgramContext, RunnableFunction,
 };
 use IString;
 
@@ -261,7 +261,7 @@ fn create_words_fun(_: Arguments) -> CreateFunctionResult {
     create_file_fun(args)
 }
 
-pub const SELECT_FROM_FILE_BUILTIN: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const SELECT_FROM_FILE_BUILTIN: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
     function_name: "select_from_file",
     description: "Selects random regions from the given file, using the given delimiter (most commonly a newline)",
     arguments: &[
@@ -270,15 +270,15 @@ pub const SELECT_FROM_FILE_BUILTIN: &FunctionPrototype = &FunctionPrototype::Bui
     ],
     variadic: false,
     create_fn: &create_file_fun,
-});
+};
 
-pub const WORDS_BUILTIN: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const WORDS_BUILTIN: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
     function_name: "words",
     description: "Selects a random word from the unix words file (/usr/share/dict/words or /usr/dict/words)",
     arguments: &[],
     variadic: false,
     create_fn: &create_words_fun,
-});
+};
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/from_file.rs
+++ b/src/builtins/from_file.rs
@@ -251,7 +251,7 @@ fn create_words_fun(_: Arguments) -> CreateFunctionResult {
         .map(|path| ConstString::new(*path))
         .ok_or_else(|| {
             format_err!(
-                "Could not find a words file in the usual places: {:?}",
+                "Could not find a words file in the usual places: {:?} Try using `select_from_file(String, String)` instead",
                 words_paths
             )
         })?;

--- a/src/builtins/from_file.rs
+++ b/src/builtins/from_file.rs
@@ -223,53 +223,6 @@ fn find_region_offsets(file: &mut File, delimiter: &str) -> Result<Vec<u64>, io:
     Ok(result)
 }
 
-// pub fn select_from_file_fun() -> BuiltinFunctionCreator {
-//     let args = ArgsBuilder::new()
-//         .arg("delimiter", GeneratorType::String)
-//         .arg("file_path", GeneratorType::String)
-//         .build();
-//     BuiltinFunctionCreator {
-//         name: SELECT_FROM_FILE_FUN_NAME.into(),
-//         description: "Selects random regions from the given file, using the given delimiter (most commonly a newline)",
-//         args,
-//         create_fn: &create_select
-//     }
-// }
-// fn create_select(mut args: Vec<GeneratorArg>, _: &ProgramContext) -> Result<GeneratorArg, Error> {
-//     let delimiter = args.pop().unwrap().as_string();
-//     let path = args.pop().unwrap().as_string();
-//     Ok(GeneratorArg::String(SelectFromFile::new(path, delimiter)))
-// }
-
-// pub fn words_fun() -> BuiltinFunctionCreator {
-//     BuiltinFunctionCreator {
-//         name: "words".into(),
-//         description: "Selects a random word from the unix words file (/usr/share/dict/words or /usr/dict/words)",
-//         args: FunctionArgs::empty(),
-//         create_fn: &create_words_fun
-//     }
-// }
-
-// fn create_words_fun(_: Vec<GeneratorArg>, _: &ProgramContext) -> Result<GeneratorArg, Error> {
-//     use generator::constant::ConstantStringGenerator;
-//     use std::path::Path;
-
-//     let words_paths = ["/usr/share/dict/words", "/usr/dict/words"];
-//     let path = words_paths
-//         .iter()
-//         .filter(|path| Path::new(path).is_file())
-//         .next()
-//         .map(|path| ConstantStringGenerator::new(*path))
-//         .ok_or_else(|| {
-//             format_err!(
-//                 "Could not find a words file in the usual places: {:?}",
-//                 words_paths
-//             )
-//         })?;
-//     let delimiter = ConstantStringGenerator::new("\n");
-
-//     Ok(GeneratorArg::String(SelectFromFile::new(path, delimiter)))
-// }
 
 const FILEPATH_PARAM: &str = "filepath";
 const DELIMITER_PARAM: &str = "delimiter";
@@ -331,12 +284,13 @@ pub const WORDS_BUILTIN: &FunctionPrototype = &FunctionPrototype::Builtin(&Built
 mod test {
     use super::*;
     use ::ConstString;
+    use verbosity;
 
     const RAND_SEED: &[u8; 16] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
     #[test]
     fn produces_words_from_file_with_lf_line_endings() {
-        let mut rng = ProgramContext::from_seed(*RAND_SEED);
+        let mut rng = ProgramContext::from_seed(*RAND_SEED, verbosity::NORMAL);
         let path_gen = ConstString::new("test-data/simple-words.txt")
             .require_string()
             .unwrap();
@@ -352,7 +306,7 @@ mod test {
 
     #[test]
     fn produces_words_from_file_with_crlf_line_endings() {
-        let mut rng = ProgramContext::from_seed(*RAND_SEED);
+        let mut rng = ProgramContext::from_seed(*RAND_SEED, verbosity::NORMAL);
         let path_gen = ConstString::new("test-data/crlf-words.txt")
             .require_string()
             .unwrap();

--- a/src/builtins/from_file.rs
+++ b/src/builtins/from_file.rs
@@ -43,7 +43,7 @@ impl RandFileReader {
             ref region_offsets,
             ref delimiter,
         } = *self;
-        let region_idx = rng.gen_range(0, region_offsets.len() + 1);
+        let region_idx = rng.gen_range_inclusive(0, region_offsets.len());
         let region_start = if region_idx == 0 {
             0
         } else {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -11,9 +11,10 @@ mod sequence;
 mod strings;
 mod to_string;
 
-use FunctionPrototype;
+use interpreter::Module;
+use ::BuiltinFunctionPrototype;
 
-pub const BUILTIN_FNS: &'static [&'static FunctionPrototype] = &[
+const BUILTIN_FNS: &'static [&'static BuiltinFunctionPrototype] = &[
     self::bin_length::BIN_LENGTH,
     self::byte_order::UINT_LITTLE_ENDIAN,
     self::byte_order::UINT_BIG_ENDIAN,
@@ -67,3 +68,8 @@ pub const BUILTIN_FNS: &'static [&'static FunctionPrototype] = &[
     self::sequence::DECIMAL_WRAPPING_SEQ,
     self::sequence::DECIMAL_SEQ,
 ];
+
+
+pub fn get_default_builtins_module() -> Module {
+    Module::new_builtin(BUILTIN_FNS.iter().map(|fun| *fun))
+}

--- a/src/builtins/numeric.rs
+++ b/src/builtins/numeric.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use std::rc::Rc;
 use std::fmt::Debug;
 use ::{
-    AnyFunction, BuiltinFunctionPrototype, FunctionPrototype, CreateFunctionResult, DataGenOutput,
+    AnyFunction, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
     ProgramContext, RunnableFunction, GenType, Arguments, DynFun, OutputType
 };
 
@@ -43,7 +43,7 @@ macro_rules! make_numeric_builtin {
             Ok($any_fun_path(Rc::new(fun)))
         }
 
-        pub const $proto_name: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+        pub const $proto_name: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
             function_name: $fun_name,
             description: "Generates a number between the given given minimum (inclusive) and maximum (exclusive)",
             arguments: &[
@@ -52,7 +52,7 @@ macro_rules! make_numeric_builtin {
             ],
             variadic: false,
             create_fn: &$create_fn_name,
-        });
+        };
 
     };
 }

--- a/src/builtins/repeat_delim.rs
+++ b/src/builtins/repeat_delim.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use IString;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynFun,
-    DynUintFun, FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    DynUintFun, GenType, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -102,8 +102,8 @@ fn create_bin_repeat_delim(args: Arguments) -> CreateFunctionResult {
     Ok(AnyFunction::Bin(Rc::new(fun)))
 }
 
-pub const REPEAT_DELIM_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const REPEAT_DELIM_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "repeat_delimited",
         description:
             "Formats the output by repeating the given generator separated by the delimiter",
@@ -116,10 +116,10 @@ pub const REPEAT_DELIM_BUILTIN: &FunctionPrototype =
         ],
         variadic: false,
         create_fn: &create_repeat_delim,
-    });
+    };
 
-pub const REPEAT_DELIM_BIN_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const REPEAT_DELIM_BIN_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "repeat_delimited",
         description:
             "Formats the output by repeating the given generator separated by the delimiter",
@@ -132,7 +132,7 @@ pub const REPEAT_DELIM_BIN_BUILTIN: &FunctionPrototype =
         ],
         variadic: false,
         create_fn: &create_bin_repeat_delim,
-    });
+    };
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/select.rs
+++ b/src/builtins/select.rs
@@ -21,7 +21,7 @@ impl<T> StableSelectFun<T> {
         } = *self;
         let mut index = index.borrow_mut();
         if index.is_none() {
-            *index = Some(ctx.gen_range(0, wrapped.len()));
+            *index = Some(ctx.gen_range_exclusive(0, wrapped.len()));
         }
 
         wrapped[index.unwrap()].clone()
@@ -45,7 +45,7 @@ struct SelectFun<T> {
 }
 
 fn select_fun<'a, 'b, T>(ctx: &'a mut ProgramContext, values: &'b [DynFun<T>]) -> &'b DynFun<T> {
-    let i = ctx.gen_range(0, values.len());
+    let i = ctx.gen_range_exclusive(0, values.len());
     &values[i]
 }
 

--- a/src/builtins/select.rs
+++ b/src/builtins/select.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 use ::{
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynFun,
-    FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    GenType, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -72,14 +72,14 @@ macro_rules! make_select_proto {
             Ok(any)
         }
 
-        pub const $select_name: &FunctionPrototype =
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+        pub const $select_name: &BuiltinFunctionPrototype =
+            &BuiltinFunctionPrototype {
                 function_name: "select",
                 description: "Randomly selects one of the input functions",
                 arguments: &[(SELECT_ARG, $gen_type)],
                 variadic: true,
                 create_fn: &$create_select_fn_name,
-            });
+            };
 
         fn $create_stable_select_fn_name(args: Arguments) -> CreateFunctionResult {
             let as_types = args.get_required_varargs(SELECT_ARG, 0, $convert_fun)?;
@@ -91,14 +91,14 @@ macro_rules! make_select_proto {
             Ok(any)
         }
 
-        pub const $stable_select_name: &FunctionPrototype =
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+        pub const $stable_select_name: &BuiltinFunctionPrototype =
+            &BuiltinFunctionPrototype {
                 function_name: "stable_select",
                 description: "Randomly selects one of the input functions and continues to select that same function forever",
                 arguments: &[(SELECT_ARG, $gen_type)],
                 variadic: true,
                 create_fn: &$create_stable_select_fn_name,
-            });
+            };
     };
 }
 

--- a/src/builtins/sequence.rs
+++ b/src/builtins/sequence.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynFun,
-    FunctionPrototype, GenType, ProgramContext, RunnableFunction,
+    GenType, ProgramContext, RunnableFunction,
 };
 
 #[derive(Debug)]
@@ -45,7 +45,7 @@ const SEQ_ARG_NAME: &str = "generator";
 
 macro_rules! make_seq_builtin {
     ($wrapping_name:ident, $non_wrapping_name:ident, $gen_type:expr, $any_fun_path:path, $convert_arg:path) => {
-        pub const $non_wrapping_name: &FunctionPrototype = {
+        pub const $non_wrapping_name: &BuiltinFunctionPrototype = {
 
             fn create_seq(args: Arguments) -> CreateFunctionResult {
                 let values = args.get_required_varargs(SEQ_ARG_NAME, 0, $convert_arg)?;
@@ -55,7 +55,7 @@ macro_rules! make_seq_builtin {
                     wrapping: false,
                 })))
             }
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+            &BuiltinFunctionPrototype {
                 function_name: "sequence",
                 description: "Iterates over the given generators in sequence. After it reaches the end, the final generator will continue to be selected forever",
                 arguments: &[
@@ -63,9 +63,10 @@ macro_rules! make_seq_builtin {
                 ],
                 variadic: true,
                 create_fn: &create_seq
-            })
+            }
         };
-        pub const $wrapping_name: &FunctionPrototype = {
+
+        pub const $wrapping_name: &BuiltinFunctionPrototype = {
 
             fn create_wrapping_seq(args: Arguments) -> CreateFunctionResult {
                 let values = args.get_required_varargs(SEQ_ARG_NAME, 0, $convert_arg)?;
@@ -75,7 +76,7 @@ macro_rules! make_seq_builtin {
                     wrapping: true,
                 })))
             }
-            &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+            &BuiltinFunctionPrototype {
                 function_name: "wrapping_sequence",
                 description: "Iterates over the given generators in sequence, wrapping around after it reaches the end",
                 arguments: &[
@@ -83,7 +84,7 @@ macro_rules! make_seq_builtin {
                 ],
                 variadic: true,
                 create_fn: &create_wrapping_seq
-            })
+            }
         };
     };
 }

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use IString;
 use {
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput,
-    DynCharFun, DynStringFun, DynUintFun, FunctionPrototype, GenType, ProgramContext,
+    DynCharFun, DynStringFun, DynUintFun, GenType, ProgramContext,
     RunnableFunction,
 };
 
@@ -55,14 +55,14 @@ fn create_string_gen(args: Arguments) -> CreateFunctionResult {
     })))
 }
 
-pub const STRING_GEN_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const STRING_GEN_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "string",
         description: "constructs a string using the given length and character generators",
         arguments: &[("length", GenType::Uint), ("characters", GenType::Char)],
         variadic: false,
         create_fn: &create_string_gen,
-    });
+    };
 
 #[derive(Debug)]
 struct StringLength {
@@ -84,14 +84,14 @@ fn create_str_len(args: Arguments) -> CreateFunctionResult {
     Ok(AnyFunction::Uint(Rc::new(StringLength { wrapped })))
 }
 
-pub const STRING_LENGTH_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const STRING_LENGTH_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "string_length",
         description: "returns the length in utf8-encoded bytes of the generated string",
         arguments: &[("string", GenType::String)],
         variadic: false,
         create_fn: &create_str_len,
-    });
+    };
 
 #[derive(Debug)]
 struct StringBytes {
@@ -151,15 +151,15 @@ fn create_string_bytes(args: Arguments) -> CreateFunctionResult {
     Ok(AnyFunction::Bin(Rc::new(StringBytes { encoding, string })))
 }
 
-pub const STRING_ENCODE_BUILTIN: &FunctionPrototype =
-    &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+pub const STRING_ENCODE_BUILTIN: &BuiltinFunctionPrototype =
+    &BuiltinFunctionPrototype {
         function_name: "string_bytes",
         description:
             "encodes strings using the given encoding, provided as a WHATWG encoding label",
         arguments: &[("encoding", GenType::String), ("string", GenType::String)],
         variadic: false,
         create_fn: &create_string_bytes,
-    });
+    };
 
 #[cfg(test)]
 mod test {

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -264,7 +264,7 @@ mod test {
 
     #[test]
     fn std_unicode_string_fun() {
-        let expected_output = "ༀʠㅰ⻆\u{1713}ⅻףּ𐌷﹗☔\u{243d}ᜇᜑᥤ慧\u{df1}ખ@䷪ǲ𐌚ℍṄﵗ㎕𐑩︲ᵕቢ\u{2429}☖㎱ඍ∯೦₮\u{20ed}⁺⁅␌ㇹ㈤ゼ⡀Ǜԇ𐎑𐎍\u{efd0}≈𥴘き﹛ᥚ數𐎁য়ﺂᚇ⫝⟏𝀀ਗ਼ΠᏲᥜჳស႔㠛𐎌პś﹀₾ㅉ⨏⇍☹\u{1885}擎⁽୮\u{fe09}ꀬˬꂩ෨﹊Ⓗភڊ깞ᜇ੯⻃\u{fe28}\u{a55}ԟ⼜";
+        let expected_output = "ༀʡㅱ⻇\u{1714}ⅼפּ𐌷﹗☔\u{243e}ᜇᜈ⤯뻳徻အ𐌇\u{c00}ⓕ\u{3101}⟪Ⓔℒலጴ꒽⧶◯Ѣㅉ \u{242a}☖㎲ඍ∯೦₮\u{20d3}\u{6e4}⽝\u{eb4}⽭ඊㇹ㈤ゼ⡀Ǜԇ𐎒𐎍\u{efd1}\u{fe07}ᙶ﹁き﹛\u{196e}\u{e64}෴Ɯꏕ\u{7a7}ᚇ⫞⟏𝀀ਜ਼ΠᏳᥜჴស႔㩎\u{af4}ὀァ㏔◉むዤβ⟙\u{ec8}ᢟ챞㍇⁽क\u{1007b}\u{fe09}ꇛɔ᧸ꂩ෨﹊";
         let input = r#"unicode_string(100)"#;
         test_program_success(1, input, expected_output);
     }
@@ -278,7 +278,7 @@ mod test {
 
     #[test]
     fn generate_ascii_strings() {
-        let expected_output = "w6U9vomgJ4gxen0XO";
+        let expected_output = "a6OqR822C3hoTTf1";
         let input = "alphanumeric_string(uint(0, 10))";
         test_program_success(4, input, expected_output);
     }
@@ -294,7 +294,7 @@ mod test {
 
             string(10, chars())
         "#;
-        let expected_output = "ausjmhaevg";
+        let expected_output = "auspoowhgc";
         test_program_success(1, input, expected_output);
     }
 }

--- a/src/builtins/to_string.rs
+++ b/src/builtins/to_string.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display};
 use std::rc::Rc;
 use ::{
     AnyFunction, Arguments, BuiltinFunctionPrototype, CreateFunctionResult, DataGenOutput, DynFun,
-    FunctionPrototype, GenType, OutputType, ProgramContext, RunnableFunction,
+    GenType, OutputType, ProgramContext, RunnableFunction,
 };
 use IString;
 
@@ -58,13 +58,13 @@ fn create_to_string(args: Arguments) -> CreateFunctionResult {
 macro_rules! make_to_string {
     ($proto_name:ident, $gen_type:expr) => {
 
-        pub const $proto_name: &FunctionPrototype = &FunctionPrototype::Builtin(&BuiltinFunctionPrototype {
+        pub const $proto_name: &BuiltinFunctionPrototype = &BuiltinFunctionPrototype {
             function_name: "to_string",
             description: "Converts its input to a string using the default formating",
             arguments: &[(TO_STRING_PARAM, $gen_type)],
             variadic: false,
             create_fn: &create_to_string,
-        });
+        };
     };
 }
 

--- a/src/cli_opts.rs
+++ b/src/cli_opts.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use dgen::verbosity::Verbosity;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "datagen", about = "Generate random data sets")]
+#[structopt(name = "dgen", about = "Generate random data sets")]
 pub struct CliOptions {
     /// Enable debug logging to stderr. Multiple occurrences will increase the verbosity. Contradicts `quiet` if both are supplied.
     /// The default verbosity will print errors and stacktraces to stderr.
@@ -15,7 +15,11 @@ pub struct CliOptions {
     pub quiet: u32,
 
     #[structopt(subcommand)]
-    pub subcommand: SubCommand,
+    pub subcommand: Option<SubCommand>,
+
+    /// Files to run (shortcut for `dgen run --lib file1 --lib file2 -f filen`)
+    #[structopt(parse(from_os_str))]
+    pub files: Vec<PathBuf>,
 }
 
 impl CliOptions {

--- a/src/cli_opts.rs
+++ b/src/cli_opts.rs
@@ -2,22 +2,22 @@ use std::path::PathBuf;
 use dgen::verbosity::Verbosity;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "dgen", about = "Generate random data sets")]
+#[structopt(name = "dgen", about = "A language and interpreter for generating pseudo-random data", after_help = "Run `dgen <subcommand> --help` for help on specific subcommands")]
 pub struct CliOptions {
-    /// Enable debug logging to stderr. Multiple occurrences will increase the verbosity. Contradicts `quiet` if both are supplied.
+    /// Output move information to stderr. Multiple occurrences will increase the verbosity. Contradicts `quiet` if both are supplied.
     /// The default verbosity will print errors and stacktraces to stderr.
-    #[structopt(short = "V", parse(from_occurrences))]
+    #[structopt(short = "v", long = "verbose", parse(from_occurrences), raw(global = "true"))]
     pub verbose: u32,
 
     /// Make logging to stderr quieter. Contradicts `verbose` if both are supplied, so `dgen -VVV -qqq` would result in normal output.
     /// Normally, two `-q`s is enough to suppress all stderr output.
-    #[structopt(short = "q", parse(from_occurrences))]
+    #[structopt(short = "q", long = "quiet", parse(from_occurrences), raw(global = "true"))]
     pub quiet: u32,
 
     #[structopt(subcommand)]
     pub subcommand: Option<SubCommand>,
 
-    /// Files to run (shortcut for `dgen run --lib file1 --lib file2 -f filen`)
+    /// Shortcut for `dgen run --lib file1 --lib file2 -f fileN`
     #[structopt(parse(from_os_str))]
     pub files: Vec<PathBuf>,
 }

--- a/src/cli_opts.rs
+++ b/src/cli_opts.rs
@@ -1,14 +1,28 @@
 use std::path::PathBuf;
+use dgen::verbosity::Verbosity;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "datagen", about = "Generate random data sets")]
 pub struct CliOptions {
-    /// Enable debug logging to stderr. Multiple occurrences will increase the verbosity
+    /// Enable debug logging to stderr. Multiple occurrences will increase the verbosity. Contradicts `quiet` if both are supplied.
+    /// The default verbosity will print errors and stacktraces to stderr.
     #[structopt(short = "V", parse(from_occurrences))]
-    pub debug: u64,
+    pub verbose: u32,
+
+    /// Make logging to stderr quieter. Contradicts `verbose` if both are supplied, so `dgen -VVV -qqq` would result in normal output.
+    /// Normally, two `-q`s is enough to suppress all stderr output.
+    #[structopt(short = "q", parse(from_occurrences))]
+    pub quiet: u32,
 
     #[structopt(subcommand)]
     pub subcommand: SubCommand,
+}
+
+impl CliOptions {
+    pub fn get_verbosity(&self) -> Verbosity {
+        let start = self.verbose + 2; // 2 is the default verbosity. `verbose` and `quiet` will adjust from there
+        start.saturating_sub(self.quiet).into()
+    }
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cli_opts.rs
+++ b/src/cli_opts.rs
@@ -33,9 +33,14 @@ impl CliOptions {
 pub enum SubCommand {
     /// Print information on available functions
     #[structopt(name = "help")]
-    ListFunctions {
+    Help {
+        /// Print information on all functions whose name contains the given string
         #[structopt(short = "f", long = "function")]
-        name: Option<String>,
+        function_name: Option<String>,
+
+        /// Print information on a specific module
+        #[structopt(short = "m", long = "module")]
+        module_name: Option<String>,
     },
 
     /// Run a program to generate some data

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,25 +2,59 @@ use rand::distributions::uniform::SampleUniform;
 use rand::distributions::{Distribution, Standard};
 use rand::prng::XorShiftRng;
 use rand::{Rng, SeedableRng, FromEntropy};
+use std::fmt;
+use std::io;
+use verbosity::Verbosity;
+use interpreter::SourceRef;
+use failure::Error;
+use IString;
 
 pub struct ProgramContext {
     rng: XorShiftRng,
+    verbosity: Verbosity,
+    is_unwinding: bool,
+    error_output: Box<io::Write>,
+    error: Option<ProgramRuntimeError>,
 }
 
 impl ProgramContext {
-    pub fn from_seed(seed: [u8; 16]) -> ProgramContext {
+    pub fn from_seed(seed: [u8; 16], verbosity: Verbosity) -> ProgramContext {
         let rng = XorShiftRng::from_seed(seed);
-        ProgramContext::new(rng)
+        ProgramContext::new(rng, verbosity)
     }
 
-    pub fn from_random_seed() -> ProgramContext {
+    pub fn from_random_seed(verbosity: Verbosity) -> ProgramContext {
         let rng = XorShiftRng::from_entropy();
-        ProgramContext::new(rng)
+        ProgramContext::new(rng, verbosity)
     }
 
-    pub fn new(rng: XorShiftRng) -> ProgramContext {
-        ProgramContext { rng }
+    pub fn new(rng: XorShiftRng, verbosity: Verbosity) -> ProgramContext {
+        ProgramContext { 
+            rng,
+            verbosity,
+            is_unwinding: false,
+            error_output: Box::new(io::stderr()),
+            error: None,
+        }
     }
+
+    pub fn error(&mut self, function_name: &IString, source_ref: &SourceRef, error: &Error) {
+        if !self.is_unwinding {
+            self.is_unwinding = true;
+            let error = ProgramRuntimeError::new(error, self.verbosity);
+            self.error = Some(error);
+        }
+
+        if self.verbosity.should_print_stacktrace() {
+            self.error.as_mut().unwrap().push_stack_frame(function_name, source_ref);
+        }
+    }
+
+    pub fn reset_error(&mut self) -> Option<ProgramRuntimeError> {
+        self.is_unwinding = false;
+        self.error.take()
+    }
+
 
     #[allow(dead_code)]
     pub fn gen_value<T>(&mut self) -> T
@@ -36,5 +70,93 @@ impl ProgramContext {
         max_exclusive: T,
     ) -> T {
         self.rng.gen_range(min_inclusive, max_exclusive)
+    }
+
+
+    pub fn error_output(&mut self, verbosity: Verbosity) -> Option<ErrorOutput> {
+        if self.verbosity >= verbosity {
+            Some(ErrorOutput {
+                context: self
+            })
+        } else {
+            None
+        }
+    }
+}
+
+
+pub struct ErrorOutput<'a> {
+    // reference to the context to prevent this object from outliving the context
+    // so that we can be gruaranteed that no RunnableFunction can output errors 
+    // unless it is the currently active function
+    context: &'a mut ProgramContext,
+}
+
+impl<'a> fmt::Write for ErrorOutput<'a> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.context.error_output.write_all(value.as_bytes()).map_err(|_| fmt::Error)
+    }
+}
+
+#[derive(Debug)]
+pub struct ProgramRuntimeError {
+    verbosity: Verbosity,
+    error_message: String,
+    stacktrace: Vec<StackFrame>,
+}
+
+impl ProgramRuntimeError {
+    fn new(error: &Error, verbosity: Verbosity) -> ProgramRuntimeError {
+        let error_message = if verbosity.should_print_debug_stacktrace() {
+            // if we're in debug mode then we'll render the debug version of the error
+            format!("Program Runtime Error: {:#?}", error)
+        } else {
+            format!("Program Runtime Error: {}", error)
+        };
+        
+        ProgramRuntimeError {
+            verbosity,
+            error_message,
+            stacktrace: Vec::with_capacity(32),
+        }
+    }
+
+    fn push_stack_frame(&mut self, function_name: &IString, source: &SourceRef) {
+        self.stacktrace.push(StackFrame{ 
+            function_name: function_name.clone(),
+            source_ref: source.clone(),
+        });
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StackFrame {
+    function_name: IString,
+    source_ref: SourceRef,
+}
+
+impl fmt::Display for StackFrame {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} at {}:{}", self.function_name, self.source_ref.description(), self.source_ref.start_line_number())
+    }
+}
+
+impl fmt::Display for ProgramRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+
+        writeln!(f, "{}", self.error_message.as_str())?;
+        if self.verbosity.is_verbose() && !self.stacktrace.is_empty() {
+            // if we're being verbose, then print source_ref of the first stack frame
+            let source_ref = &self.stacktrace[0].source_ref;
+            writeln!(f, "{}", source_ref)?;
+        }
+
+        if self.verbosity.should_print_stacktrace() {
+            writeln!(f, "Stacktrace: ")?;
+            for (index, frame) in self.stacktrace.iter().enumerate() {
+                writeln!(f, "{:>3}: {}", index, frame)?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -64,12 +64,44 @@ impl ProgramContext {
         self.rng.gen()
     }
 
-    pub fn gen_range<T: PartialOrd + SampleUniform>(
+    pub fn gen_range_exclusive<T: PartialOrd + Copy + SampleUniform>(
         &mut self,
         min_inclusive: T,
-        max_exclusive: T,
+        max_inclusive: T,
     ) -> T {
-        self.rng.gen_range(min_inclusive, max_exclusive)
+        use rand::distributions::Uniform;
+        let min = if min_inclusive < max_inclusive {
+            min_inclusive
+        } else {
+            max_inclusive
+        };
+        let max = if min_inclusive > max_inclusive {
+            min_inclusive
+        } else {
+            max_inclusive
+        };
+        let distribution = Uniform::new(min, max);
+        distribution.sample(&mut self.rng)
+    }
+
+    pub fn gen_range_inclusive<T: PartialOrd + Copy + SampleUniform>(
+        &mut self,
+        min_inclusive: T,
+        max_inclusive: T,
+    ) -> T {
+        use rand::distributions::Uniform;
+        let min = if min_inclusive < max_inclusive {
+            min_inclusive
+        } else {
+            max_inclusive
+        };
+        let max = if min_inclusive > max_inclusive {
+            min_inclusive
+        } else {
+            max_inclusive
+        };
+        let distribution = Uniform::new_inclusive(min, max);
+        distribution.sample(&mut self.rng)
     }
 
 

--- a/src/fun_test.rs
+++ b/src/fun_test.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use program::Program;
 use writer::DataGenOutput;
 use ProgramContext;
-use interpreter::Source;
+use interpreter::UnreadSource;
 
 #[test]
 fn signed_integer_functions() {
@@ -105,15 +105,15 @@ fn calling_a_function_with_module_name() {
     "##;
 
     let mut runner = Program::new(2, 1, "lib2.foo()".to_owned(), create_context());
-    runner.add_library(Source::Builtin("lib1", lib1)).unwrap();
-    runner.add_library(Source::Builtin("lib2", lib2)).unwrap();
+    runner.add_library(UnreadSource::Builtin("lib1", lib1)).unwrap();
+    runner.add_library(UnreadSource::Builtin("lib2", lib2)).unwrap();
 
     let result = run_to_string(runner);
     assert_eq!("lib2foo", &result);
 
     let mut runner = Program::new(2, 1, "lib1.foo()".to_owned(), create_context());
-    runner.add_library(Source::Builtin("lib1", lib1)).unwrap();
-    runner.add_library(Source::Builtin("lib2", lib2)).unwrap();
+    runner.add_library(UnreadSource::Builtin("lib1", lib1)).unwrap();
+    runner.add_library(UnreadSource::Builtin("lib2", lib2)).unwrap();
 
     let result = run_to_string(runner);
     assert_eq!("lib1foo", &result);
@@ -150,9 +150,9 @@ fn adding_multiple_default_modules_that_each_define_the_same_function_retuns_err
     "##;
 
     let mut runner = Program::new(2, 1, "bar()".to_owned(), create_context());
-    runner.add_library(Source::string(lib1)).expect("First lib should be added OK");
+    runner.add_library(UnreadSource::string(lib1)).expect("First lib should be added OK");
 
-    let result = runner.add_library(Source::string(lib2));
+    let result = runner.add_library(UnreadSource::string(lib2));
     assert!(result.is_err());
     let error = result.unwrap_err();
     let err_str = format!("{}", error);

--- a/src/fun_test.rs
+++ b/src/fun_test.rs
@@ -139,28 +139,6 @@ fn adding_a_library_that_defines_two_functions_with_the_same_signature_returns_e
     assert!(err_str.contains("Module 'default' contains multiple functions with the same signature"), "Error string was incorrect. Actual error: {}", err_str);
 }
 
-#[test]
-fn adding_multiple_default_modules_that_each_define_the_same_function_retuns_error() {
-    let lib1 = r##"
-    # the first foo function
-    def foo(i: Uint) = alphanumeric_string(i);
-    "##;
-
-    let lib2 = r##"
-    # the second foo function
-    def foo(i: Uint) = unicode_string(i);
-    "##;
-
-    let mut runner = Runner::new(VERBOSITY, 1, "bar()".to_owned(), create_context());
-    runner.add_library(UnreadSource::string(lib1)).expect("First lib should be added OK");
-
-    let result = runner.add_library(UnreadSource::string(lib2));
-    assert!(result.is_err());
-    let error = result.unwrap_err();
-    let err_str = format!("{}", error);
-    assert!(err_str.contains("Module 'default' contains multiple functions with the same signature"), "Error string was incorrect. Actual error: {}", err_str);
-}
-
 const RAND_SEED: &[u8; 16] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
 pub fn create_context() -> ProgramContext {

--- a/src/fun_test.rs
+++ b/src/fun_test.rs
@@ -9,13 +9,13 @@ const VERBOSITY: ::verbosity::Verbosity = ::verbosity::NORMAL;
 #[test]
 fn signed_integer_functions() {
     let input = r#"int(-9, +7)"#;
-    let expected_output = "-9";
+    let expected_output = "-6";
     test_program_success(1, input, expected_output);
 }
 
 #[test]
 fn declare_and_use_functions() {
-    let expected_output = "aw6IU9vomgJ42f1aT0XOE";
+    let expected_output = "aw6OqR822CZggJ42f1aT0";
     let input = r#"
         def foo(len: Uint) = alphanumeric_string(len);
         def bar() = foo(7);
@@ -42,7 +42,7 @@ fn use_binary_functions() {
 #[test]
 fn stable_select_a_generator() {
     let input = r#"stable_select(select("a", "b"), select("c", "d"))"#;
-    let expected_output = "aabbbbbbaa";
+    let expected_output = "aabbbbbaba";
     test_program_success(10, input, expected_output);
 }
 
@@ -66,7 +66,7 @@ fn declare_and_use_function_with_mapper() {
 
         concat(repeat_words(count()), repeat_words(count()))
     "#;
-    let expected = "2 : w6IU9\nw6IU9\nvomgJ\nvomgJ\n4 : 2f1aT\n2f1aT\n2f1aT\n0XOET\n0XOET\n0XOET\n9Vk0R\n9Vk0R\n9Vk0R\n";
+    let expected = "2 : w6OqR\nw6OqR\n822CZ\n822CZ\n3 : gJ42f\ngJ42f\n1aT0X\n1aT0X\n";
     test_program_success(1, input, expected);
 }
 
@@ -78,7 +78,7 @@ fn pass_mapped_function_as_function_argument() {
 
         compare_words(alphanumeric_string(1) { w -> repeat_delimited(3, w, ", ") } )
     "#;
-    let expected = "a, a, a != w, w, w\n6, 6, 6 != I, I, I\nU, U, U != 9, 9, 9\n";
+    let expected = "a, a, a != w, w, w\n6, 6, 6 != O, O, O\nq, q, q != R, R, R\n";
     test_program_success(1, input, expected);
 }
 

--- a/src/fun_test.rs
+++ b/src/fun_test.rs
@@ -119,6 +119,46 @@ fn calling_a_function_with_module_name() {
     assert_eq!("lib1foo", &result);
 }
 
+#[test]
+fn adding_a_library_that_defines_two_functions_with_the_same_signature_returns_error() {
+    let lib = r##"
+    # the first foo function
+    def foo(i: Uint) = alphanumeric_string(i);
+
+    # the second foo function
+    def foo(i: Uint) = unicode_string(i);
+    "##;
+
+    let mut runner = Program::new(2, 1, "bar()".to_owned(), create_context());
+    let result = runner.add_library(lib.to_owned());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    let err_str = format!("{}", error);
+    assert!(err_str.contains("Module 'default' contains multiple functions with the same signature"), "Error string was incorrect. Actual error: {}", err_str);
+}
+
+#[test]
+fn adding_multiple_default_modules_that_each_define_the_same_function_retuns_error() {
+    let lib1 = r##"
+    # the first foo function
+    def foo(i: Uint) = alphanumeric_string(i);
+    "##;
+
+    let lib2 = r##"
+    # the second foo function
+    def foo(i: Uint) = unicode_string(i);
+    "##;
+
+    let mut runner = Program::new(2, 1, "bar()".to_owned(), create_context());
+    runner.add_library(Source::string(lib1)).expect("First lib should be added OK");
+
+    let result = runner.add_library(Source::string(lib2));
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    let err_str = format!("{}", error);
+    assert!(err_str.contains("Module 'default' contains multiple functions with the same signature"), "Error string was incorrect. Actual error: {}", err_str);
+}
+
 const RAND_SEED: &[u8; 16] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
 pub fn create_context() -> ProgramContext {

--- a/src/interpreter/ast.rs
+++ b/src/interpreter/ast.rs
@@ -2,6 +2,12 @@ use std::fmt::{self, Display};
 use std::str::Chars;
 use ::IString;
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum GenType {
     Char,
@@ -36,14 +42,14 @@ impl Display for GenType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionCall {
     pub function_name: IString,
-    pub args: Vec<Expr>,
+    pub args: Vec<WithSpan<Expr>>,
     pub mapper: Option<Box<FunctionMapper>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionMapper {
     pub arg_name: IString,
-    pub mapper_body: Expr,
+    pub mapper_body: WithSpan<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -60,6 +66,20 @@ pub enum Expr {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct WithSpan<T> {
+    pub span: Span,
+    pub value: T,
+}
+
+impl<T> ::std::ops::Deref for WithSpan<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct MacroArgument {
     pub name: IString,
     pub arg_type: GenType,
@@ -70,13 +90,13 @@ pub struct MacroDef {
     pub doc_comments: String,
     pub name: IString,
     pub args: Vec<MacroArgument>,
-    pub body: Expr,
+    pub body: WithSpan<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
-    pub assignments: Vec<MacroDef>,
-    pub expr: Option<Expr>,
+    pub assignments: Vec<WithSpan<MacroDef>>,
+    pub expr: Option<WithSpan<Expr>>,
 }
 
 pub fn process_string_escapes(input: &str) -> Result<IString, &'static str> {

--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -5,6 +5,26 @@ use ::FunctionPrototype;
 use itertools::Itertools;
 use std::fmt::{self, Display};
 
+pub fn no_such_argument(name: IString) -> Error {
+    format_err!("No such argument: '{}'", name)
+}
+
+pub fn no_such_module(name: IString) -> Error {
+    format_err!("No such module: '{}'", name)
+}
+
+pub fn no_such_method(name: IString, arguments: &[AnyFunction]) -> Error {
+    use itertools::Itertools;
+    format_err!("No such method: '{}({})'", name, arguments.iter().map(|a| a.get_type()).join(", "))
+}
+
+pub fn ambiguous_varargs_functions(name: IString, arguments: &[AnyFunction], option1: &FunctionPrototype, option2: &FunctionPrototype) -> Error {
+    let actual_arg_types = arguments.iter().map(AnyFunction::get_type).join(", ");
+
+    format_err!("Ambiguous function call: '{}({})' could refer to two or more function prototypes:\nA: {}\nB: {}\n",
+        name, actual_arg_types, option1, option2)
+}
+
 /// Used to display a region of a source file when there is an error
 pub struct SourceErrRegion<'a> {
     source: &'a str,
@@ -109,20 +129,4 @@ line    3: foo
     */
     let expected = "line    3|     foo\n               ^\n";
     assert_eq!(expected, rendered.as_str());
-}
-
-pub fn no_such_argument(name: IString) -> Error {
-    format_err!("No such argument: '{}'", name)
-}
-
-pub fn no_such_method(name: IString, arguments: &[AnyFunction]) -> Error {
-    use itertools::Itertools;
-    format_err!("No such method: '{}({})'", name, arguments.iter().map(|a| a.get_type()).join(", "))
-}
-
-pub fn ambiguous_varargs_functions(name: IString, arguments: &[AnyFunction], option1: &FunctionPrototype, option2: &FunctionPrototype) -> Error {
-    let actual_arg_types = arguments.iter().map(AnyFunction::get_type).join(", ");
-
-    format_err!("Ambiguous function call: '{}({})' could refer to two or more function prototypes:\nA: {}\nB: {}\n",
-        name, actual_arg_types, option1, option2)
 }

--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -36,10 +36,16 @@ impl Display for SourceRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let source_name = self.source.description();
         let source_str = self.source.text();
-        let region = SourceErrRegion::new(&source_str, self.span.start);
-        let line_number = region.get_line_number();
 
-        write!(f, "{}:{}\n\n{}\n", source_name, line_number, region)
+        if f.alternate() {
+            let region = &source_str[self.span.start..self.span.end];
+            write!(f, "{}", region)
+        } else {
+            let region = SourceErrRegion::new(&source_str, self.span.start);
+            let line_number = region.get_line_number();
+
+            write!(f, "{}:{}\n\n{}\n", source_name, line_number, region)
+        }
     }
 }
 

--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -19,6 +19,17 @@ impl SourceRef {
     pub fn new(source: Arc<Source>, span: Span) -> SourceRef {
         SourceRef { source, span }
     }
+
+    pub fn start_line_number(&self) -> usize {
+        let start_offset = self.span.start;
+        let source_str = self.source.text();
+        let err_region = SourceErrRegion::new(source_str, start_offset);
+        err_region.get_line_number()
+    }
+
+    pub fn description(&self) -> &str {
+        self.source.description()
+    }
 }
 
 impl Display for SourceRef {

--- a/src/interpreter/grammar.lalrpop
+++ b/src/interpreter/grammar.lalrpop
@@ -13,6 +13,13 @@ Comma<E>: Vec<E> = {
     <v0:(<E> ",")*> <e1:E?> => v0.into_iter().chain(e1).collect()
 };
 
+WithSpan<E>: ast::WithSpan<E> = {
+    <start:@L> <e:E> <end:@R> => ast::WithSpan {
+        span: ast::Span { start, end },
+        value: e,
+    }
+}
+
 BooleanLiteral: bool = {
     "true" => true,
     "false" => false
@@ -63,17 +70,21 @@ BinLiteral: Vec<u8> = {
     }
 }
 
-pub Expr: ast::Expr = {
-    <c:Comment*> <b:BinLiteral> => ast::Expr::BinaryLiteral(b),
-    <c:Comment*> <l:CharLiteral> => ast::Expr::CharLiteral(l),
-    <c:Comment*> <b:BooleanLiteral> => ast::Expr::BooleanLiteral(b),
-    <c:Comment*> <s:StringLiteral> => ast::Expr::StringLiteral(s),
-    <c:Comment*> <i:IntLiteral> => ast::Expr::IntLiteral(i),
-    <c:Comment*> <i:SignedIntLiteral> => ast::Expr::SignedIntLiteral(i),
-    <c:Comment*> <d:DecimalLiteral> => ast::Expr::DecimalLiteral(d),
-    <c:Comment*> <f:FunctionCall> => ast::Expr::Function(f),
-    <c:Comment*> <n:FunctionName> => ast::Expr::ArgumentUsage(n)
+ExprInner: ast::Expr = {
+    <b:BinLiteral> => ast::Expr::BinaryLiteral(b),
+    <l:CharLiteral> => ast::Expr::CharLiteral(l),
+    <b:BooleanLiteral> => ast::Expr::BooleanLiteral(b),
+    <s:StringLiteral> => ast::Expr::StringLiteral(s),
+    <i:IntLiteral> => ast::Expr::IntLiteral(i),
+    <i:SignedIntLiteral> => ast::Expr::SignedIntLiteral(i),
+    <d:DecimalLiteral> => ast::Expr::DecimalLiteral(d),
+    <f:FunctionCall> => ast::Expr::Function(f),
+    <n:FunctionName> => ast::Expr::ArgumentUsage(n)
 };
+
+pub Expr: ast::WithSpan<ast::Expr> = {
+    <c:Comment*> <e:WithSpan<ExprInner>> <c2:Comment*> => e
+}
 
 FunctionCall: ast::FunctionCall = {
     <n:FunctionName>"(" <a:Comma<Expr>> ")" => ast::FunctionCall { function_name: n, args: a, mapper: None },
@@ -107,8 +118,18 @@ MacroArg: ast::MacroArgument = {
     <n:FunctionName> ":" <t:GenType>  => ast::MacroArgument {name: n, arg_type: t}
 }
 
-DefineMacro: ast::MacroDef = {
-    <c:Comment*> "def" <n:FunctionName> "(" <args:Comma<MacroArg>> ")" "=" <e:Expr> ";" => ast::MacroDef { name: n, args: args, body: e, doc_comments: process_doc_comments(c) }
+DefineMacro: ast::WithSpan<ast::MacroDef> = {
+    <c:Comment*> <start:@L> "def" <n:FunctionName> "(" <args:Comma<MacroArg>> ")" "=" <e:Expr> ";" <end:@R> => {
+        ast::WithSpan {
+            span: ast::Span {start, end },
+            value: ast::MacroDef { 
+                name: n, 
+                args: args, 
+                body: e, 
+                doc_comments: process_doc_comments(c) 
+            }
+        }
+    }
 }
 
 

--- a/src/interpreter/grammar.lalrpop
+++ b/src/interpreter/grammar.lalrpop
@@ -90,7 +90,7 @@ FunctionCall: ast::FunctionCall = {
 };
 
 FunctionName: IString = {
-    <s:r"[a-zA-Z]+\w*"> => s.into()
+    <s:r"[a-zA-Z]+[a-zA-Z0-9_]*(\.[a-zA-Z0-9_]+)?"> => s.into()
 };
 
 GenType: GenType = {

--- a/src/interpreter/libraries.rs
+++ b/src/interpreter/libraries.rs
@@ -1,22 +1,22 @@
-use ::interpreter::Source;
+use ::interpreter::UnreadSource;
 
 macro_rules! include_lib {
     ($name:expr, $filename:expr) => {
         {
             const LIB_CONTENT: &'static str = include_str!(concat!("../../dgen_libs/", $filename));
-            &Source::Builtin($name, LIB_CONTENT)
+            &UnreadSource::Builtin($name, LIB_CONTENT)
         }
     };
 }
 
-const CHARS: &'static Source = include_lib!("std.chars", "std/chars.dgen");
-const STRINGS: &'static Source = include_lib!("std.strings", "std/strings.dgen");
-const NUMBERS: &'static Source = include_lib!("std.numbers", "std/numbers.dgen");
-const BOOLEAN: &'static Source = include_lib!("std.boolean", "std/boolean.dgen");
-const REPEATS: &'static Source = include_lib!("std.repeats", "std/repeats.dgen");
+const CHARS: &'static UnreadSource = include_lib!("std.chars", "std/chars.dgen");
+const STRINGS: &'static UnreadSource = include_lib!("std.strings", "std/strings.dgen");
+const NUMBERS: &'static UnreadSource = include_lib!("std.numbers", "std/numbers.dgen");
+const BOOLEAN: &'static UnreadSource = include_lib!("std.boolean", "std/boolean.dgen");
+const REPEATS: &'static UnreadSource = include_lib!("std.repeats", "std/repeats.dgen");
 
 
-pub const STDLIBS: &[&Source] = &[
+pub const STDLIBS: &[&UnreadSource] = &[
     CHARS,
     STRINGS,
     NUMBERS,

--- a/src/interpreter/libraries.rs
+++ b/src/interpreter/libraries.rs
@@ -1,19 +1,19 @@
 use ::interpreter::Source;
 
 macro_rules! include_lib {
-    ($name:expr) => {
+    ($name:expr, $filename:expr) => {
         {
-            const LIB_CONTENT: &'static str = include_str!(concat!("../../dgen_libs/", $name));
+            const LIB_CONTENT: &'static str = include_str!(concat!("../../dgen_libs/", $filename));
             &Source::Builtin($name, LIB_CONTENT)
         }
     };
 }
 
-const CHARS: &'static Source = include_lib!("std/chars.dgen");
-const STRINGS: &'static Source = include_lib!("std/strings.dgen");
-const NUMBERS: &'static Source = include_lib!("std/numbers.dgen");
-const BOOLEAN: &'static Source = include_lib!("std/boolean.dgen");
-const REPEATS: &'static Source = include_lib!("std/repeats.dgen");
+const CHARS: &'static Source = include_lib!("std.chars", "std/chars.dgen");
+const STRINGS: &'static Source = include_lib!("std.strings", "std/strings.dgen");
+const NUMBERS: &'static Source = include_lib!("std.numbers", "std/numbers.dgen");
+const BOOLEAN: &'static Source = include_lib!("std.boolean", "std/boolean.dgen");
+const REPEATS: &'static Source = include_lib!("std.repeats", "std/repeats.dgen");
 
 
 pub const STDLIBS: &[&Source] = &[

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5,6 +5,7 @@ mod map;
 mod module;
 pub(crate) mod parser;
 mod source;
+pub(crate) mod prototype;
 
 #[cfg(test)]
 mod parse_test;
@@ -14,12 +15,13 @@ pub(crate) mod grammar {
     include!(concat!(env!("OUT_DIR"), "/interpreter/grammar.rs"));
 }
 
-pub use self::source::Source;
+pub use self::source::{Source, UnreadSource};
 pub use self::module::Module;
+pub use self::errors::{CompileError, SourceRef};
 
 pub const MODULE_SEPARATOR_CHAR: char = '.';
 
-use self::ast::{Expr, FunctionCall, FunctionMapper, Program};
+use self::ast::{Expr, FunctionCall, FunctionMapper, Program, WithSpan};
 use self::map::{create_memoized_fun, finish_mapped};
 use builtins::BUILTIN_FNS;
 use failure::Error;
@@ -28,10 +30,13 @@ use {
     AnyFunction, BoundArgument, ConstBin, ConstBoolean, ConstChar, ConstDecimal, ConstInt,
     ConstString, ConstUint, CreateFunctionResult, FunctionPrototype,
 };
+use std::sync::Arc;
 
 pub struct Compiler {
     modules: Vec<Module>,
 }
+
+pub type CompileResult = Result<AnyFunction, CompileError>;
 
 impl Compiler {
     fn new() -> Compiler {
@@ -49,13 +54,20 @@ impl Compiler {
         Ok(())
     }
 
-    pub fn eval(&self, expr: &Expr) -> CreateFunctionResult {
-        self.eval_private(expr, &[])
+    pub fn eval(&self, source: Arc<Source>, expr: &WithSpan<Expr>) -> CompileResult {
+        self.eval_private(source, expr, &[])
     }
 
-    pub fn eval_private(&self, expr: &Expr, bound_args: &[BoundArgument]) -> CreateFunctionResult {
-        match *expr {
-            Expr::ArgumentUsage(ref name) => self.eval_arg_usage(name.clone(), bound_args),
+    pub fn eval_private(&self, source: Arc<Source>, expr: &WithSpan<Expr>, bound_args: &[BoundArgument]) -> CompileResult {
+        let source_ref = SourceRef {
+            source,
+            span: expr.span.clone()
+        };
+        match expr.value {
+            Expr::Function(ref call) => self.eval_function_call(call, bound_args, source_ref),
+            Expr::ArgumentUsage(ref name) => self.eval_arg_usage(name.clone(), bound_args, &source_ref),
+
+            // literals are easy and can't really fail
             Expr::BooleanLiteral(ref lit) => Ok(ConstBoolean::new(*lit)),
             Expr::StringLiteral(ref lit) => Ok(ConstString::new(lit.clone())),
             Expr::IntLiteral(ref lit) => Ok(ConstUint::new(*lit)),
@@ -63,7 +75,6 @@ impl Compiler {
             Expr::DecimalLiteral(ref lit) => Ok(ConstDecimal::new(*lit)),
             Expr::CharLiteral(ref lit) => Ok(ConstChar::new(*lit)),
             Expr::BinaryLiteral(ref lit) => Ok(ConstBin::new(lit.clone())),
-            Expr::Function(ref call) => self.eval_function_call(call, bound_args),
         }
     }
 
@@ -84,9 +95,9 @@ impl Compiler {
         self.modules.iter_mut().find(|module| name == &module.name)
     }
 
-    fn get_module(&self, name: &IString) -> Result<&Module, Error> {
+    fn get_module(&self, name: &IString, source_ref: &SourceRef) -> Result<&Module, CompileError> {
         self.modules.iter().find(|module| name == &module.name).ok_or_else(|| {
-            errors::no_such_module(name.clone())
+            CompileError::no_such_module(name.clone(), source_ref.clone())
         })
     }
 
@@ -94,12 +105,14 @@ impl Compiler {
         &self,
         call: &FunctionCall,
         bound_args: &[BoundArgument],
-    ) -> CreateFunctionResult {
+        source_ref: SourceRef
+    ) -> CompileResult {
         // first eval all the arguments for the function call and collect the results in an array
         // Any error here will short circuit the eval
         let mut resolved_args = Vec::with_capacity(call.args.len());
         for arg in call.args.iter() {
-            let arg_result = self.eval_private(arg, bound_args)?;
+            // pass the source along when evaluating the arguments for the call
+            let arg_result = self.eval_private(source_ref.source.clone(), arg, bound_args)?;
             resolved_args.push(arg_result);
         }
 
@@ -112,14 +125,14 @@ impl Compiler {
             .map(|bound| bound.value.clone());
 
         if resolved.is_none() {
-            let function = self.find_matching_function(name, resolved_args.as_slice())?;
-            let res = function.apply(resolved_args, self)?;
+            let function = self.find_matching_function(source_ref.clone(), name, resolved_args.as_slice())?;
+            let res = function.apply(resolved_args, self, &source_ref)?;
             resolved = Some(res);
         }
         let resolved = resolved.unwrap();
 
         if let Some(mapper) = call.mapper.as_ref() {
-            self.eval_mapped_function(resolved, mapper, bound_args)
+            self.eval_mapped_function(source_ref.source, resolved, mapper, bound_args)
         } else {
             Ok(resolved)
         }
@@ -127,10 +140,11 @@ impl Compiler {
 
     fn eval_mapped_function(
         &self,
+        source: Arc<Source>,
         resolved_outer: AnyFunction,
         mapper: &FunctionMapper,
         bound_args: &[BoundArgument],
-    ) -> CreateFunctionResult {
+    ) -> CompileResult {
         let (memoized, resetter) = create_memoized_fun(resolved_outer);
         let bound_arg = BoundArgument::new(mapper.arg_name.clone(), memoized);
         let mut all_bound_args = Vec::with_capacity(bound_args.len() + 1);
@@ -139,36 +153,37 @@ impl Compiler {
             all_bound_args.push(arg.clone());
         }
 
-        let mapped = self.eval_private(&mapper.mapper_body, all_bound_args.as_slice())?;
+        let mapped = self.eval_private(source, &mapper.mapper_body, all_bound_args.as_slice())?;
         let resolved = finish_mapped(mapped, resetter);
         Ok(resolved)
     }
 
     fn find_matching_function<'a, 'b>(
         &'a self,
+        source_ref: SourceRef,
         name: IString,
         arguments: &'b [AnyFunction],
-    ) -> Result<&'a FunctionPrototype, Error> {
+    ) -> Result<&'a FunctionPrototype, CompileError> {
         let name_clone = name.clone();
 
         if let Some((module_name, function_name)) = split_module_and_function(&*name) {
-            let matching_module = self.get_module(&module_name)?;
+            let matching_module = self.get_module(&module_name, &source_ref)?;
             let function_iter = matching_module.find_function(&function_name).ok_or_else(|| {
-                errors::no_such_method(name, arguments)
+                CompileError::no_such_method(name, arguments, source_ref.clone())
             })?;
-            filter_matching_arguments(name_clone, arguments, function_iter)
+            filter_matching_arguments(name_clone, arguments, function_iter, &source_ref)
         } else {
             let iter = self.find_function(name);
-            filter_matching_arguments(name_clone, arguments, iter)
+            filter_matching_arguments(name_clone, arguments, iter, &source_ref)
         }
     }
 
-    fn eval_arg_usage(&self, name: IString, bound_args: &[BoundArgument]) -> CreateFunctionResult {
+    fn eval_arg_usage(&self, name: IString, bound_args: &[BoundArgument], source_ref: &SourceRef) -> CompileResult {
         let bound_arg = bound_args
             .iter()
             .filter(|a| a.arg_name == name)
             .next()
-            .ok_or_else(|| errors::no_such_argument(name))?;
+            .ok_or_else(|| CompileError::no_such_argument(name, source_ref.clone()))?;
 
         Ok(bound_arg.value.clone())
     }
@@ -186,7 +201,7 @@ fn builtin_functions<'a>(name: IString) -> impl Iterator<Item = &'a FunctionProt
     BUILTIN_FNS.iter().filter(move |fun| fun.name() == &*name).map(|f| *f)
 }
 
-fn filter_matching_arguments<'a, I: Iterator<Item = &'a FunctionPrototype>>(name: IString, arguments: &[AnyFunction], iter: I) -> Result<&'a FunctionPrototype, Error> {
+fn filter_matching_arguments<'a, I: Iterator<Item = &'a FunctionPrototype>>(name: IString, arguments: &[AnyFunction], iter: I, source_ref: &SourceRef) -> Result<&'a FunctionPrototype, CompileError> {
     let mut current_best: Option<&'a FunctionPrototype> = None;
 
     for candidate in iter {
@@ -198,14 +213,14 @@ fn filter_matching_arguments<'a, I: Iterator<Item = &'a FunctionPrototype>>(name
             } else {
                 let option1 = current_best.unwrap();
 
-                return Err(errors::ambiguous_varargs_functions(
-                    name, arguments, option1, candidate,
+                return Err(CompileError::ambiguous_varargs_functions(
+                    name, arguments, option1, candidate, source_ref.clone()
                 ));
             }
         }
     }
     current_best.ok_or_else(|| {
-        errors::no_such_method(name, arguments)
+        CompileError::no_such_method(name, arguments, source_ref.clone())
     })
 }
 
@@ -222,43 +237,44 @@ impl Interpreter {
 
     pub fn add_std_lib(&mut self) {
         for lib in self::libraries::STDLIBS.iter() {
-            self.add_module(lib)
+            let source = (*lib).clone();
+            self.add_module(source)
                 .expect("Failed to add std library. This is a bug!");
         }
     }
 
-    pub fn add_module(&mut self, source: &Source) -> Result<(), Error> {
-        use std::borrow::Borrow;
-
-        let module_name: IString = source.get_name();
-        let text = source.read_to_str()?;
-        let parsed = parser::parse_program(module_name.clone(), text.borrow())?;
-        let module = Module::new(module_name, parsed.assignments)?;
+    pub fn add_module(&mut self, unread_source: UnreadSource) -> Result<(), Error> {
+        let source = Source::read(unread_source)?;
+        let module_name: IString = source.module_name();
+        let parsed = {
+            parser::parse_program(module_name, source.text())?
+        };
+        let module = Module::new(Arc::new(source), parsed.assignments)?;
         self.internal.add_module(module)
     }
 
-    pub fn eval(&mut self, program: &str) -> CreateFunctionResult {
-        let module_name: IString = "main".into();
-        let Program { assignments, expr } = parser::parse_program(module_name.clone(), program)?;
-
-        if let Some(expression) = expr {
-            let main_module = Module::new(module_name, assignments)?;
-            self.internal.add_module(main_module)?;
-
-            self.internal.eval(&expression)
-        } else {
-            bail!("The program does not end with an expression. An expression is required")
-        }
+    pub fn eval(&mut self, unread_source: UnreadSource) -> CreateFunctionResult {
+        self.eval_any(unread_source).and_then(|maybe_function| {
+            maybe_function.ok_or_else(|| {
+                format_err!("The program does not end with an expression. An expression is required")
+            })
+        })
     }
 
-    pub fn eval_any(&mut self, program: &str) -> Result<Option<AnyFunction>, Error> {
-        let module_name: IString = "main".into();
-        let Program { assignments, expr } = parser::parse_program(module_name.clone(), program)?;
-        let main_module = Module::new(module_name, assignments)?;
-        self.internal.add_module(main_module)?;
+    pub fn eval_any(&mut self, unread_source: UnreadSource) -> Result<Option<AnyFunction>, Error> {
+        let source = Source::read(unread_source)?;
+        let module_name: IString = source.module_name();
+        
+        let Program { assignments, expr } = {
+            parser::parse_program(module_name.clone(), source.text())?
+        };
+
+        let source_ref = Arc::new(source);
+        let module = Module::new(source_ref.clone(), assignments)?;
+        self.internal.add_module(module)?;
 
         if let Some(expression) = expr {
-            let function = self.internal.eval(&expression)?;
+            let function = self.internal.eval(source_ref, &expression)?;
             Ok(Some(function))
         } else {
             Ok(None)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -6,6 +6,7 @@ mod module;
 pub(crate) mod parser;
 mod source;
 pub(crate) mod prototype;
+mod runtime_wrapper;
 
 #[cfg(test)]
 mod parse_test;
@@ -125,11 +126,11 @@ impl Compiler {
             .map(|bound| bound.value.clone());
 
         if resolved.is_none() {
-            let function = self.find_matching_function(source_ref.clone(), name, resolved_args.as_slice())?;
+            let function = self.find_matching_function(source_ref.clone(), name.clone(), resolved_args.as_slice())?;
             let res = function.apply(resolved_args, self, &source_ref)?;
             resolved = Some(res);
         }
-        let resolved = resolved.unwrap();
+        let resolved = runtime_wrapper::wrap(resolved.unwrap(), name.clone(), source_ref.clone());
 
         if let Some(mapper) = call.mapper.as_ref() {
             self.eval_mapped_function(source_ref.source, resolved, mapper, bound_args)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -285,4 +285,8 @@ impl Interpreter {
     pub fn function_iterator(&self) -> impl Iterator<Item = &FunctionPrototype> {
         self.internal.function_iterator()
     }
+
+    pub fn module_iterator(&self) -> impl Iterator<Item = &Module> {
+        self.internal.modules.iter()
+    }
 }

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -1,0 +1,41 @@
+use IString;
+use prototype::FunctionPrototype;
+use interpreter::ast::MacroDef;
+use failure::Error;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Module {
+    pub name: IString,
+    functions: HashMap<IString, Vec<FunctionPrototype>>,
+}
+
+impl Module {
+    pub fn new(name: IString, function_defs: Vec<MacroDef>) -> Result<Module, Error> {
+        let mut functions = HashMap::with_capacity(32);
+
+        for function in function_defs.into_iter() {
+            let new_function_name = function.name.clone();
+            let new_function = FunctionPrototype::new(function);
+            
+            let mut existing: &mut Vec<FunctionPrototype> = functions.entry(new_function_name).or_insert(Vec::new());
+
+            if let Some(other_fun) = existing.iter().find(|existing| existing.is_same_signature(&new_function)) {
+                bail!("Module '{}' contains multiple functions with the same signature. \nA: {} \nB: {}", name, other_fun, new_function);
+            }
+            existing.push(new_function);
+        }
+
+        Ok(Module {
+            name, functions
+        })
+    }
+
+    pub fn find_function(&self, name: &IString) -> Option<impl Iterator<Item = &FunctionPrototype>> {
+        self.functions.get(name).map(|funs| funs.iter())
+    }
+
+    pub fn function_iterator(&self) -> impl Iterator<Item = &FunctionPrototype> {
+        self.functions.values().flat_map(|funs| funs.iter())
+    }
+}

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -1,7 +1,7 @@
 use IString;
-use interpreter::prototype::{FunctionPrototype, InterpretedFunctionPrototype};
+use interpreter::prototype::{FunctionPrototype, BuiltinFunctionPrototype, InterpretedFunctionPrototype};
 use interpreter::ast::{WithSpan, MacroDef};
-use interpreter::Source;
+use interpreter::{Source, UnreadSource};
 use failure::Error;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,6 +28,20 @@ impl Module {
         }
 
         Ok(module)
+    }
+
+    pub fn new_builtin<I: Iterator<Item = &'static BuiltinFunctionPrototype>>(builtin_fns: I) -> Module {
+        use std::borrow::Cow;
+        let mut module = Module {
+            name: IString::from("dgen"),
+            source: Arc::new(Source::new(UnreadSource::Builtin("dgen", ""), Cow::Borrowed(""))),
+            functions: HashMap::with_capacity(64),
+        };
+
+        for fun in builtin_fns {
+            module.add_function(FunctionPrototype::Builtin(fun)).expect("Failed to add builtin function to builtin module");
+        }
+        module
     }
 
     pub fn combine(&mut self, Module {functions, ..}: Module) -> Result<(), Error> {

--- a/src/interpreter/module.rs
+++ b/src/interpreter/module.rs
@@ -12,23 +12,38 @@ pub struct Module {
 
 impl Module {
     pub fn new(name: IString, function_defs: Vec<MacroDef>) -> Result<Module, Error> {
-        let mut functions = HashMap::with_capacity(32);
+        let mut module = Module {
+            name,
+            functions: HashMap::with_capacity(32)
+        };
 
         for function in function_defs.into_iter() {
-            let new_function_name = function.name.clone();
             let new_function = FunctionPrototype::new(function);
-            
-            let mut existing: &mut Vec<FunctionPrototype> = functions.entry(new_function_name).or_insert(Vec::new());
-
-            if let Some(other_fun) = existing.iter().find(|existing| existing.is_same_signature(&new_function)) {
-                bail!("Module '{}' contains multiple functions with the same signature. \nA: {} \nB: {}", name, other_fun, new_function);
-            }
-            existing.push(new_function);
+            module.add_function(new_function)?;
         }
 
-        Ok(Module {
-            name, functions
-        })
+        Ok(module)
+    }
+
+    pub fn combine(&mut self, Module {functions, ..}: Module) -> Result<(), Error> {
+        for (_, function_list) in functions.into_iter() {
+            for new_function in function_list {
+                self.add_function(new_function)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add_function(&mut self, new_function: FunctionPrototype) -> Result<(), Error> {
+        let Module { ref name, ref mut functions } = *self;
+        let new_function_name = new_function.name().into();
+        let existing: &mut Vec<FunctionPrototype> = functions.entry(new_function_name).or_insert(Vec::new());
+
+        if let Some(other_fun) = existing.iter().find(|existing| existing.is_same_signature(&new_function)) {
+            bail!("Module '{}' contains multiple functions with the same signature. \nA: {} \nB: {}", name, other_fun, new_function);
+        }
+        existing.push(new_function);
+        Ok(())
     }
 
     pub fn find_function(&self, name: &IString) -> Option<impl Iterator<Item = &FunctionPrototype>> {

--- a/src/interpreter/parse_test.rs
+++ b/src/interpreter/parse_test.rs
@@ -1,5 +1,5 @@
 use ::interpreter::ast::{
-    Expr, FunctionCall, FunctionMapper, GenType, MacroArgument, MacroDef, Program,
+    Expr, FunctionCall, FunctionMapper, GenType, MacroArgument, MacroDef, Program, WithSpan, Span,
 };
 use ::interpreter::grammar::ExprParser;
 use ::interpreter::parser::parse_program;
@@ -8,61 +8,61 @@ use IString;
 #[test]
 fn parses_boolean_literal_false_token() {
     let result = ExprParser::new().parse(r#"false"#);
-    assert_eq!(Ok(boolean(false)), result);
+    assert_eq!(Ok(with_span(0, 5, boolean(false))), result);
 }
 
 #[test]
 fn parses_boolean_literal_true_token() {
     let result = ExprParser::new().parse(r#"true"#);
-    assert_eq!(Ok(boolean(true)), result);
+    assert_eq!(Ok(with_span(0, 4, boolean(true))), result);
 }
 
 #[test]
 fn parses_unsigned_int_literal_token() {
     let result = ExprParser::new().parse(r#"1234"#);
-    assert_eq!(Ok(int(1234)), result);
+    assert_eq!(Ok(with_span(0, 4, int(1234))), result);
 }
 
 #[test]
 fn parses_unsigned_int_hex_literal_token() {
     let result = ExprParser::new().parse("0xFF");
-    assert_eq!(Ok(int(255)), result);
+    assert_eq!(Ok(with_span(0, 4, int(255))), result);
 }
 
 #[test]
 fn parses_signed_int_literal_negative_token() {
     let result = ExprParser::new().parse(r#"-1234"#);
-    assert_eq!(Ok(sint(-1234)), result);
+    assert_eq!(Ok(with_span(0, 5, sint(-1234))), result);
 }
 
 #[test]
 fn parses_signed_int_literal_positive_token() {
     let result = ExprParser::new().parse(r#"+1234"#);
-    assert_eq!(Ok(sint(1234)), result);
+    assert_eq!(Ok(with_span(0, 5, sint(1234))), result);
 }
 
 #[test]
 fn parses_string_literal_with_escaped_quotes() {
     let result = ExprParser::new().parse(r#""some\"str""#);
-    assert_eq!(Ok(string(r#"some"str"#)), result);
+    assert_eq!(Ok(with_span(0, 11, string(r#"some"str"#))), result);
 }
 
 #[test]
 fn parses_decimal_literal_token() {
     let result = ExprParser::new().parse(r#"123.45"#);
-    assert_eq!(Ok(float(123.45)), result);
+    assert_eq!(Ok(with_span(0, 6, float(123.45))), result);
 }
 
 #[test]
 fn parses_decimal_literal_token_with_negative_sign() {
     let result = ExprParser::new().parse(r#"-123.45"#);
-    assert_eq!(Ok(float(-123.45)), result);
+    assert_eq!(Ok(with_span(0, 7, float(-123.45))), result);
 }
 
 #[test]
 fn parses_decimal_literal_token_with_positive_sign() {
     let result = ExprParser::new().parse(r#"+123.45"#);
-    assert_eq!(Ok(float(123.45)), result);
+    assert_eq!(Ok(with_span(0, 7, float(123.45))), result);
 }
 
 #[test]
@@ -106,13 +106,13 @@ fn parses_function_call_with_literal_arguments() {
     let expected = FunctionCall {
         function_name: "fun_name".into(),
         args: vec![
-            Expr::StringLiteral("foo".into()),
-            Expr::IntLiteral(55),
-            Expr::DecimalLiteral(12.5),
+            with_span(9, 14, Expr::StringLiteral("foo".into())),
+            with_span(16, 18, Expr::IntLiteral(55)),
+            with_span(20, 24, Expr::DecimalLiteral(12.5))
         ],
         mapper: None,
     };
-    assert_eq!(Ok(Expr::Function(expected)), result);
+    assert_eq!(Ok(with_span(0, 25, Expr::Function(expected))), result);
 }
 
 #[test]
@@ -123,20 +123,25 @@ fn parses_function_call_with_zero_arguments() {
         args: Vec::new(),
         mapper: None,
     };
-    assert_eq!(Ok(Expr::Function(expected)), result);
+    assert_eq!(Ok(with_span(0, 10, Expr::Function(expected))), result);
 }
 
 #[test]
 fn parses_nested_function_calls() {
     let result = ExprParser::new().parse(r#"fun1("foo", fun2(12.5, fun3(111)), "bar")"#);
-    let expected = fun(
+    let expected = with_span(0, 41, fun(
         "fun1",
         vec![
-            string("foo"),
-            fun("fun2", vec![float(12.5), fun("fun3", vec![int(111)])]),
-            string("bar"),
+            with_span(5, 10, string("foo")),
+            with_span(12, 33, fun("fun2", vec![
+                with_span(17, 21, float(12.5)), 
+                with_span(23, 32, fun("fun3", vec![
+                    with_span(28, 31, int(111))
+                ]))
+            ])),
+            with_span(35, 40, string("bar")),
         ],
-    );
+    ));
     assert_eq!(Ok(expected), result);
 }
 
@@ -146,15 +151,15 @@ fn parses_mapped_function_call() {
         inner(mapper_arg, mapper_arg)
     }"#;
     let result = ExprParser::new().parse(input);
-    let expected = mfun(
+    let expected = with_span(0, 73, mfun(
         "fun1",
-        vec![string("foo"), int(7)],
+        vec![with_span(5, 10, string("foo")), with_span(12, 13, int(7))],
         "mapper_arg",
-        fun(
+        with_span(38, 67, fun(
             "inner",
-            vec![arg_usage("mapper_arg"), arg_usage("mapper_arg")],
-        ),
-    );
+            vec![with_span(44, 54, arg_usage("mapper_arg")), with_span(56, 66, arg_usage("mapper_arg"))],
+        )),
+    ));
     assert_eq!(Ok(expected), result);
 }
 
@@ -164,15 +169,15 @@ fn parses_mapped_function_call_withou_args() {
         inner(mapper_arg, mapper_arg)
     }"#;
     let result = ExprParser::new().parse(input);
-    let expected = mfun(
+    let expected = with_span(0, 65, mfun(
         "fun1",
         Vec::new(),
         "mapper_arg",
-        fun(
+        with_span(30, 59, fun(
             "inner",
-            vec![arg_usage("mapper_arg"), arg_usage("mapper_arg")],
-        ),
-    );
+            vec![with_span(36, 46, arg_usage("mapper_arg")), with_span(48, 58, arg_usage("mapper_arg"))],
+        )),
+    ));
     assert_eq!(Ok(expected), result);
 }
 
@@ -192,39 +197,39 @@ fn parses_program_with_macro_definitions() {
     "#;
     let expected = Program {
         assignments: vec![
-            MacroDef {
+            with_span(28, 70, MacroDef {
                 name: s("wtf"),
                 args: vec![MacroArgument {
                     name: s("count"),
                     arg_type: GenType::Uint,
                 }],
-                body: Expr::Function(FunctionCall {
+                body: with_span(51, 69, Expr::Function(FunctionCall {
                     function_name: s("asciiString"),
-                    args: vec![arg_usage("count")],
+                    args: vec![with_span(63, 68, arg_usage("count"))],
                     mapper: None,
-                }),
+                })),
                 doc_comments: "comment 1".to_owned(),
-            },
-            MacroDef {
+            }),
+            with_span(114, 142, MacroDef {
                 name: s("foo"),
                 args: Vec::new(),
-                body: Expr::Function(FunctionCall {
+                body: with_span(126, 141, Expr::Function(FunctionCall {
                     function_name: s("wtf"),
-                    args: vec![Expr::Function(FunctionCall {
+                    args: vec![with_span(130, 140, Expr::Function(FunctionCall {
                         function_name: s("uint"),
-                        args: vec![Expr::IntLiteral(0), Expr::IntLiteral(9)],
+                        args: vec![with_span(135, 136, Expr::IntLiteral(0)), with_span(138, 139, Expr::IntLiteral(9))],
                         mapper: None,
-                    })],
+                    }))],
                     mapper: None,
-                }),
+                })),
                 doc_comments: "comment 2\ncomment 3".to_owned(),
-            },
+            }),
         ],
-        expr: Some(Expr::Function(FunctionCall {
+        expr: Some(with_span(184, 189, Expr::Function(FunctionCall {
             function_name: s("foo"),
             args: Vec::new(),
             mapper: None,
-        })),
+        }))),
     };
 
     let actual = parse_program("test input".into(), input).expect("failed to parse input");
@@ -234,7 +239,7 @@ fn parses_program_with_macro_definitions() {
 #[test]
 fn parses_bin_literal() {
     let input = "[ 0x00,0xff, 0x01]";
-    let expected_output = bin(&[0x00, 0xff, 0x01]);
+    let expected_output = with_span(0, 18, bin(&[0x00, 0xff, 0x01]));
     let actual = ExprParser::new().parse(input).expect("failed to parse");
     assert_eq!(expected_output, actual);
 }
@@ -242,7 +247,7 @@ fn parses_bin_literal() {
 #[test]
 fn parses_empty_bin_literal() {
     let input = "[ ]";
-    let expected_output = bin(&[]);
+    let expected_output = with_span(0, 3, bin(&[]));
     let actual = ExprParser::new().parse(input).expect("failed to parse");
     assert_eq!(expected_output, actual);
 }
@@ -257,16 +262,16 @@ fn arg_usage(name: &str) -> Expr {
 }
 
 fn string_literal_test(to_parse: &str, expected: &str) {
-    let actual = ExprParser::new().parse(to_parse);
-    assert_eq!(Ok(Expr::StringLiteral(s(expected))), actual);
+    let actual = ExprParser::new().parse(to_parse).expect("failed to parse");
+    assert_eq!(Expr::StringLiteral(s(expected)), actual.value);
 }
 
 fn char_literal_test(to_parse: &str, expected: char) {
-    let actual = ExprParser::new().parse(to_parse);
-    assert_eq!(Ok(ch(expected)), actual);
+    let actual = ExprParser::new().parse(to_parse).expect("failed to parse");
+    assert_eq!(ch(expected), actual.value);
 }
 
-fn fun(name: &str, args: Vec<Expr>) -> Expr {
+fn fun(name: &str, args: Vec<WithSpan<Expr>>) -> Expr {
     Expr::Function(FunctionCall {
         function_name: name.into(),
         args,
@@ -274,7 +279,7 @@ fn fun(name: &str, args: Vec<Expr>) -> Expr {
     })
 }
 
-fn mfun(name: &str, args: Vec<Expr>, mapper_arg_name: &str, mapper_body: Expr) -> Expr {
+fn mfun(name: &str, args: Vec<WithSpan<Expr>>, mapper_arg_name: &str, mapper_body: WithSpan<Expr>) -> Expr {
     Expr::Function(FunctionCall {
         function_name: name.into(),
         args,
@@ -311,4 +316,14 @@ fn sint(i: i64) -> Expr {
 
 fn bin(bytes: &[u8]) -> Expr {
     Expr::BinaryLiteral(bytes.to_owned())
+}
+
+fn with_span<T>(start: usize, end: usize, value: T) -> WithSpan<T> {
+    WithSpan {
+        span: Span {
+            start,
+            end,
+        },
+        value,
+    }
 }

--- a/src/interpreter/prototype.rs
+++ b/src/interpreter/prototype.rs
@@ -134,7 +134,7 @@ pub struct ArgumentTypes {
     pub types: Vec<GenType>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FunctionPrototype {
     Builtin(&'static BuiltinFunctionPrototype),
     Interpreted(InterpretedFunctionPrototype),

--- a/src/interpreter/prototype.rs
+++ b/src/interpreter/prototype.rs
@@ -1,17 +1,12 @@
-use interpreter::ast::{Expr, MacroArgument, MacroDef};
-use interpreter::Compiler;
+use interpreter::ast::{WithSpan, Expr, MacroArgument, MacroDef};
+use interpreter::{Source, SourceRef, Compiler, CompileResult, CompileError};
 use ::{AnyFunction, Arguments, GenType};
 use std::fmt::{self, Debug, Display};
 use IString;
+use std::sync::Arc;
 
 use failure::Error;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct SourceRef {
-    filename: IString,
-    line: u32,
-    column: u32,
-}
 
 pub type CreateFunctionResult = Result<AnyFunction, Error>;
 
@@ -24,10 +19,11 @@ pub trait FunProto {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InterpretedFunctionPrototype {
+    source_ref: SourceRef,
     function_name: IString,
     arguments: Vec<MacroArgument>,
     doc_comments: String, // no point in interning these
-    body: Expr,
+    body: WithSpan<Expr>,
 }
 
 impl FunProto for InterpretedFunctionPrototype {
@@ -49,27 +45,30 @@ impl FunProto for InterpretedFunctionPrototype {
     }
 }
 
-impl From<MacroDef> for InterpretedFunctionPrototype {
-    fn from(macro_def: MacroDef) -> InterpretedFunctionPrototype {
-        InterpretedFunctionPrototype::new(macro_def)
-    }
-}
 
 impl InterpretedFunctionPrototype {
-    fn new(macro_def: MacroDef) -> InterpretedFunctionPrototype {
+    pub fn new(source: Arc<Source>, macro_def: WithSpan<MacroDef>) -> InterpretedFunctionPrototype {
+        let WithSpan {
+            span,
+            value,
+        } = macro_def;
+
         let MacroDef {
             doc_comments,
             name,
             args,
             body,
-        } = macro_def;
+        } = value;
+
         InterpretedFunctionPrototype {
+            source_ref: SourceRef::new(source, span),
             function_name: name,
             doc_comments,
             arguments: args,
             body,
         }
     }
+
     fn bind_arguments(&self, mut args: Vec<AnyFunction>) -> Vec<BoundArgument> {
         args.drain(..).enumerate().map(|(i, value)| {
             // the bounds check should have been taken care previously of by the type checking
@@ -79,9 +78,10 @@ impl InterpretedFunctionPrototype {
         }).collect()
     }
 
-    fn apply(&self, args: Vec<AnyFunction>, compiler: &Compiler) -> CreateFunctionResult {
+    fn apply(&self, args: Vec<AnyFunction>, compiler: &Compiler) -> CompileResult {
         let bound_args = self.bind_arguments(args);
-        compiler.eval_private(&self.body, bound_args.as_slice())
+        let source = self.source_ref.source.clone();
+        compiler.eval_private(source, &self.body, bound_args.as_slice()).map_err(Into::into)
     }
 }
 
@@ -248,9 +248,13 @@ impl FunctionPrototype {
         }
     }
 
-    pub fn apply(&self, arguments: Vec<AnyFunction>, compiler: &Compiler) -> CreateFunctionResult {
+    pub fn apply(&self, arguments: Vec<AnyFunction>, compiler: &Compiler, source_ref: &SourceRef) -> Result<AnyFunction, CompileError> {
         match *self {
-            FunctionPrototype::Builtin(ref builtin) => builtin.apply(arguments),
+            FunctionPrototype::Builtin(ref builtin) => {
+                builtin.apply(arguments).map_err(|err| {
+                    CompileError::internal_error(err, source_ref.clone())
+                })
+            }
             FunctionPrototype::Interpreted(ref int) => int.apply(arguments, compiler),
         }
     }
@@ -274,6 +278,15 @@ impl FunctionPrototype {
             FunctionPrototype::Builtin(ref bi) => bi.get_description(),
             FunctionPrototype::Interpreted(ref int) => int.get_description(),
         }
+    }
+
+    pub fn collect_argument_types(&self) -> Vec<GenType> {
+        let arg_count = self.get_arg_count();
+        let mut result = Vec::with_capacity(arg_count);
+        for i in 0..arg_count {
+            result.push(self.get_arg(i).1);
+        }
+        result
     }
 }
 

--- a/src/interpreter/runtime_wrapper.rs
+++ b/src/interpreter/runtime_wrapper.rs
@@ -1,0 +1,54 @@
+
+use ::{AnyFunction, RunnableFunction, DynFun, DataGenOutput, ProgramContext, IString};
+use failure::Error;
+use interpreter::SourceRef;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+
+#[derive(Debug)]
+pub struct RuntimeWrapper<T: Debug + 'static> {
+    wrapped: DynFun<T>,
+    function_name: IString,
+    source_ref: SourceRef,
+}
+
+pub fn wrap(any_function: AnyFunction, function_name: IString, source_ref: SourceRef) -> AnyFunction {
+    match any_function {
+        AnyFunction::Boolean(fun) => AnyFunction::Boolean(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::Bin(fun) => AnyFunction::Bin(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::Char(fun) => AnyFunction::Char(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::String(fun) => AnyFunction::String(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::Uint(fun) => AnyFunction::Uint(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::Int(fun) => AnyFunction::Int(RuntimeWrapper::new(fun, function_name, source_ref)),
+        AnyFunction::Decimal(fun) => AnyFunction::Decimal(RuntimeWrapper::new(fun, function_name, source_ref)),
+    }
+}
+
+impl<T: Debug + 'static> RuntimeWrapper<T> {
+
+    fn new(wrapped: DynFun<T>, function_name: IString, source_ref: SourceRef) -> DynFun<T> {
+        Rc::new(RuntimeWrapper {wrapped, function_name, source_ref })
+    }
+
+    fn handle_error<S>(&self, result: Result<S, Error>, context: &mut ProgramContext) -> Result<S, Error> {
+        if let Some(err) = result.as_ref().err() {
+            context.error(&self.function_name, &self.source_ref, err);
+        }
+        result
+    }
+}
+
+
+impl<T: Debug + 'static> RunnableFunction<T> for RuntimeWrapper<T> {
+    fn gen_value(&self, context: &mut ProgramContext) -> Result<T, Error> {
+        let result = self.wrapped.gen_value(context);
+        self.handle_error(result, context)
+    }
+
+    fn write_value(&self, context: &mut ProgramContext, out: &mut DataGenOutput) -> Result<u64, Error> {
+        let result = self.wrapped.write_value(context, out);
+        self.handle_error(result, context)
+    }
+}
+

--- a/src/interpreter/source.rs
+++ b/src/interpreter/source.rs
@@ -2,6 +2,7 @@ use failure::Error;
 use std::borrow::Cow;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use IString;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Source {
@@ -15,19 +16,23 @@ pub enum Source {
     Stdin,
 }
 
+fn default_module_name() -> IString {
+    "main".into()
+}
+
 impl Source {
-    pub fn get_name(&self) -> String {
+    pub fn get_name(&self) -> IString {
         match *self {
             Source::File(ref pb) => pb
                 .file_name()
                 .map(|name| {
                     name.to_str()
-                        .map(::std::borrow::ToOwned::to_owned)
-                        .unwrap_or_else(|| "unknown file".to_owned())
-                }).unwrap_or_else(|| "unknown file".to_owned()),
-            Source::String(_) => "string input".to_owned(),
-            Source::Builtin(ref name, _) => (*name).to_owned(),
-            Source::Stdin => "stdin".to_owned(),
+                        .map(Into::into)
+                        .unwrap_or_else(|| default_module_name())
+                }).unwrap_or_else(|| default_module_name()),
+            Source::String(_) => default_module_name(),
+            Source::Builtin(ref name, _) => (*name).into(),
+            Source::Stdin => default_module_name(),
         }
     }
     pub fn file<P: Into<PathBuf>>(path: P) -> Source {

--- a/src/interpreter/source.rs
+++ b/src/interpreter/source.rs
@@ -4,8 +4,9 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use IString;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Source {
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum UnreadSource {
     /// reference to a file on the local filesystem. The filename will become the module name
     File(PathBuf),
     /// source is held entirely in memory
@@ -20,67 +21,111 @@ fn default_module_name() -> IString {
     "default".into()
 }
 
-impl Source {
+impl UnreadSource {
     pub fn get_name(&self) -> IString {
         match *self {
-            Source::File(ref pb) => pb
+            UnreadSource::File(ref pb) => pb
                 .file_stem()
                 .map(|name| {
                     name.to_str()
                         .map(Into::into)
                         .unwrap_or_else(|| default_module_name())
                 }).unwrap_or_else(|| default_module_name()),
-            Source::String(_) => default_module_name(),
-            Source::Builtin(ref name, _) => (*name).into(),
-            Source::Stdin => default_module_name(),
+            UnreadSource::String(_) => default_module_name(),
+            UnreadSource::Builtin(ref name, _) => (*name).into(),
+            UnreadSource::Stdin => default_module_name(),
         }
     }
-    pub fn file<P: Into<PathBuf>>(path: P) -> Source {
-        Source::File(path.into())
-    }
-    pub fn string<S: Into<String>>(string: S) -> Source {
-        Source::String(string.into())
-    }
-    pub fn stdin() -> Source {
-        Source::Stdin
+
+    pub fn get_description(&self) -> &str {
+        match *self {
+            UnreadSource::File(ref pb) => pb.to_str().unwrap_or("<unknown file>"),
+            UnreadSource::String(_) => "<command line input>",
+            UnreadSource::Builtin(ref name, _) => name,
+            UnreadSource::Stdin => "<stdin>",
+        }
     }
 
-    pub fn read_to_str<'a>(&'a self) -> Result<Cow<'a, str>, Error> {
-        match *self {
-            Source::File(ref path) => {
+    pub fn file<P: Into<PathBuf>>(path: P) -> UnreadSource {
+        UnreadSource::File(path.into())
+    }
+
+    pub fn string<S: Into<String>>(string: S) -> UnreadSource {
+        UnreadSource::String(string.into())
+    }
+
+    pub fn stdin() -> UnreadSource {
+        UnreadSource::Stdin
+    }
+
+}
+
+impl From<String> for UnreadSource {
+    fn from(s: String) -> UnreadSource {
+        UnreadSource::string(s)
+    }
+}
+
+impl<'a> From<&'a Path> for UnreadSource {
+    fn from(p: &'a Path) -> UnreadSource {
+        UnreadSource::file(p)
+    }
+}
+
+impl From<PathBuf> for UnreadSource {
+    fn from(p: PathBuf) -> UnreadSource {
+        UnreadSource::file(p)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Source {
+    unread: UnreadSource,
+    source_text: Cow<'static, str>,
+}
+
+impl Source {
+    pub fn read(mut unread: UnreadSource) -> Result<Source, Error> {
+        let source_text = match &mut unread {
+            UnreadSource::File(ref path) => {
                 use std::fs::File;
                 let mut file = File::open(path)?;
                 let mut buffer = String::with_capacity(512);
                 file.read_to_string(&mut buffer)?;
-                Ok(buffer.into())
+                Cow::from(buffer)
             }
-            Source::String(ref string) => Ok(string.as_str().into()),
-            Source::Builtin(_, ref builtin) => Ok((*builtin).into()),
-            Source::Stdin => {
+            UnreadSource::Builtin(_, src) => Cow::from(*src),
+            UnreadSource::String(ref mut src) => {
+                // ok, this is admittedly a little weird. We're going to swap the unread source with an empty string
+                // so that we don't need to copy it. In all likelyhood any source with this type was small enough to get passed
+                // on the command line, so the copy would be no big deal, but avoiding the copy will be better in the case that anyone
+                // uses this as a library
+                Cow::from(::std::mem::replace(src, String::new()))
+            }
+            UnreadSource::Stdin => {
                 let mut sin = io::stdin();
-                let mut buffer = String::with_capacity(512);
+                let mut buffer = String::with_capacity(32);
                 sin.read_to_string(&mut buffer)?;
-                Ok(buffer.into())
+                Cow::from(buffer)
             }
-        }
-    }
-}
+        };
 
-impl From<String> for Source {
-    fn from(s: String) -> Source {
-        Source::string(s)
+        Ok(Source {
+            unread,
+            source_text,
+        })
     }
-}
 
-impl<'a> From<&'a Path> for Source {
-    fn from(p: &'a Path) -> Source {
-        Source::file(p)
+    pub fn text(&self) -> &str {
+        &self.source_text
     }
-}
 
-impl From<PathBuf> for Source {
-    fn from(p: PathBuf) -> Source {
-        Source::file(p)
+    pub fn module_name(&self) -> IString {
+        self.unread.get_name()
+    }
+
+    pub fn description(&self) -> &str {
+        self.unread.get_description()
     }
 }
 
@@ -92,7 +137,7 @@ mod test {
     #[test]
     fn filename_minus_extension_is_used_as_module_name() {
         let path = Path::new("/foo/bar/baz.dgen");
-        let source = Source::from(path);
+        let source = UnreadSource::from(path);
 
         let name = source.get_name();
         assert_eq!("baz", &*name);

--- a/src/interpreter/source.rs
+++ b/src/interpreter/source.rs
@@ -6,7 +6,7 @@ use IString;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Source {
-    /// reference to a file on the local filesystem
+    /// reference to a file on the local filesystem. The filename will become the module name
     File(PathBuf),
     /// source is held entirely in memory
     String(String),
@@ -17,14 +17,14 @@ pub enum Source {
 }
 
 fn default_module_name() -> IString {
-    "main".into()
+    "default".into()
 }
 
 impl Source {
     pub fn get_name(&self) -> IString {
         match *self {
             Source::File(ref pb) => pb
-                .file_name()
+                .file_stem()
                 .map(|name| {
                     name.to_str()
                         .map(Into::into)
@@ -81,5 +81,20 @@ impl<'a> From<&'a Path> for Source {
 impl From<PathBuf> for Source {
     fn from(p: PathBuf) -> Source {
         Source::file(p)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+    use super::*;
+
+    #[test]
+    fn filename_minus_extension_is_used_as_module_name() {
+        let path = Path::new("/foo/bar/baz.dgen");
+        let source = Source::from(path);
+
+        let name = source.get_name();
+        assert_eq!("baz", &*name);
     }
 }

--- a/src/interpreter/source.rs
+++ b/src/interpreter/source.rs
@@ -116,6 +116,13 @@ impl Source {
         })
     }
 
+    pub fn new(original: UnreadSource, source_text: Cow<'static, str>) -> Source {
+        Source {
+            unread: original,
+            source_text,
+        }
+    }
+
     pub fn text(&self) -> &str {
         &self.source_text
     }

--- a/src/interpreter/source.rs
+++ b/src/interpreter/source.rs
@@ -17,7 +17,7 @@ pub enum UnreadSource {
     Stdin,
 }
 
-fn default_module_name() -> IString {
+pub fn default_module_name() -> IString {
     "default".into()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod interpreter;
 pub mod program;
 mod types;
 mod writer;
+pub mod verbosity;
 
 #[cfg(test)]
 mod fun_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ pub(crate) mod builtins;
 mod context;
 pub mod interpreter;
 pub mod program;
-mod prototype;
 mod types;
 mod writer;
 
@@ -27,7 +26,7 @@ pub use self::arguments::Arguments;
 pub use self::context::ProgramContext;
 pub use self::interpreter::ast::GenType;
 pub use self::interpreter::{Interpreter, Source};
-pub use self::prototype::{
+pub use self::interpreter::prototype::{
     BoundArgument, BuiltinFunctionCreator, BuiltinFunctionPrototype, CreateFunctionResult,
     FunctionPrototype, InterpretedFunctionPrototype,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod cli_opts;
 
 use self::cli_opts::{CliOptions, SubCommand};
 use dgen::program::Program;
-use dgen::interpreter::Source;
+use dgen::interpreter::UnreadSource;
 use dgen::ProgramContext;
 use failure::Error;
 use std::path::PathBuf;
@@ -93,9 +93,9 @@ fn get_program_source(
     program_string: Option<String>,
     program_file: Option<PathBuf>,
     stdin: bool,
-) -> Result<Source, Error> {
+) -> Result<UnreadSource, Error> {
     let maybe_source = if stdin {
-        Some(Source::stdin())
+        Some(UnreadSource::stdin())
     } else if program_string.is_some() {
         program_string.map(Into::into)
     } else if program_file.is_some() {
@@ -108,7 +108,7 @@ fn get_program_source(
 }
 
 fn create_program(
-    program_source: Source,
+    program_source: UnreadSource,
     verbosity: u64,
     iterations: u64,
     libraries: Vec<PathBuf>,
@@ -121,7 +121,7 @@ fn create_program(
         program.add_std_lib();
     }
     for lib in libraries {
-        program.add_library(Source::file(lib))?;
+        program.add_library(UnreadSource::file(lib))?;
     }
     Ok(program)
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,18 +1,18 @@
 use failure::Error;
 use writer::DataGenOutput;
 
-use ::interpreter::{Interpreter, Source};
+use ::interpreter::{Interpreter, UnreadSource};
 use ::ProgramContext;
 
 pub struct Program {
     iterations: u64,
-    source: Source,
+    source: UnreadSource,
     rng: ProgramContext,
     interpreter: Interpreter,
 }
 
 impl Program {
-    pub fn new<T: Into<Source>>(
+    pub fn new<T: Into<UnreadSource>>(
         _verbosity: u64,
         iterations: u64,
         source: T,
@@ -35,8 +35,7 @@ impl Program {
             ..
         } = self;
 
-        let src_string = source.read_to_str()?;
-        let gen = interpreter.eval(src_string.as_ref())?;
+        let gen = interpreter.eval(source)?;
 
         for _ in 0..iterations {
             gen.write_value(&mut rng, output)?;
@@ -48,8 +47,8 @@ impl Program {
         self.interpreter.add_std_lib();
     }
 
-    pub fn add_library<T: Into<Source>>(&mut self, lib_source: T) -> Result<(), Error> {
+    pub fn add_library<T: Into<UnreadSource>>(&mut self, lib_source: T) -> Result<(), Error> {
         let source = lib_source.into();
-        self.interpreter.add_module(&source)
+        self.interpreter.add_module(source)
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -2,35 +2,36 @@ use failure::Error;
 use writer::DataGenOutput;
 
 use ::interpreter::{Interpreter, UnreadSource};
+use verbosity::Verbosity;
 use ::ProgramContext;
 
-pub struct Program {
+pub struct Runner {
     iterations: u64,
     source: UnreadSource,
-    rng: ProgramContext,
+    runtime_context: ProgramContext,
     interpreter: Interpreter,
 }
 
-impl Program {
+impl Runner {
     pub fn new<T: Into<UnreadSource>>(
-        _verbosity: u64,
+        _verbosity: Verbosity,
         iterations: u64,
         source: T,
-        rng: ProgramContext,
-    ) -> Program {
-        Program {
+        runtime_context: ProgramContext,
+    ) -> Runner {
+        Runner {
             iterations,
             source: source.into(),
-            rng,
+            runtime_context,
             interpreter: Interpreter::new(),
         }
     }
 
     pub fn run(self, output: &mut DataGenOutput) -> Result<(), Error> {
-        let Program {
+        let Runner {
             iterations,
             source,
-            mut rng,
+            mut runtime_context,
             mut interpreter,
             ..
         } = self;
@@ -38,7 +39,10 @@ impl Program {
         let gen = interpreter.eval(source)?;
 
         for _ in 0..iterations {
-            gen.write_value(&mut rng, output)?;
+            let result = gen.write_value(&mut runtime_context, output);
+            if let Some(err) = result.as_ref().err() {
+                handle_error(&mut runtime_context, err);
+            }
         }
         output.flush().map_err(Into::into)
     }
@@ -52,3 +56,25 @@ impl Program {
         self.interpreter.add_module(source)
     }
 }
+
+fn handle_error(context: &mut ProgramContext, error: &Error) {
+    use std::fmt::Write;
+
+    if let Some(mut out) = context.error_output(::verbosity::VERBOSE) {
+        writeln!(out, "Program Runtime Error: {}", error).expect(MUY_MALO);
+    } 
+    if let Some(mut out) = context.error_output(::verbosity::DGEN_DEBUG) {
+        writeln!(out, "{}", error.backtrace()).expect(MUY_MALO);
+    }
+
+
+    if let Some(program_error) = context.reset_error() {
+        // program_error should not generally indicate an error/bug in dgen itself
+        // it is generally caused by invalid code that was passed to the interpreter
+        if let Some(mut out) = context.error_output(::verbosity::QUIET) {
+            writeln!(out, "{}", program_error).expect(MUY_MALO);
+        }  
+    }
+}
+
+const MUY_MALO: &str = "Failed to print to error stream";

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,12 +71,12 @@ impl OutputType for bool {
 }
 impl OutputType for IString {
     fn write_output(&self, writer: &mut DataGenOutput) -> Result<u64, Error> {
-        writer.write_string(self).map_err(Into::into)
+        writer.write_str(&*self).map_err(Into::into)
     }
 }
 impl OutputType for str {
     fn write_output(&self, writer: &mut DataGenOutput) -> Result<u64, Error> {
-        writer.write_string(self).map_err(Into::into)
+        writer.write_str(self).map_err(Into::into)
     }
 }
 impl OutputType for Vec<u8> {

--- a/src/verbosity.rs
+++ b/src/verbosity.rs
@@ -1,0 +1,45 @@
+
+
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Debug)]
+pub struct Verbosity(u32);
+
+impl From<u32> for Verbosity {
+    fn from(verbosity: u32) -> Verbosity {
+        Verbosity(verbosity)
+    }
+}
+
+/// Nothing will ever get printed to stderr
+pub const SILENT: Verbosity = Verbosity(0);
+
+/// Only brief error messages will be printed to stderr
+pub const QUIET: Verbosity = Verbosity(1);
+
+/// Normal error messages and stacktraces will be printed to stderr
+pub const NORMAL: Verbosity = Verbosity(2);
+
+/// Print additional debug info
+pub const VERBOSE: Verbosity = Verbosity(3);
+
+/// Print dgen internal debug info and stacktraces
+pub const DGEN_DEBUG: Verbosity = Verbosity(4);
+
+impl Verbosity {
+
+    pub fn should_print_error(&self) -> bool {
+        *self >= QUIET
+    }
+
+    pub fn should_print_stacktrace(&self) -> bool {
+        *self >= NORMAL
+    }
+
+    pub fn is_verbose(&self) -> bool {
+        *self >= VERBOSE
+    }
+
+    pub fn should_print_debug_stacktrace(&self) -> bool {
+        *self >= DGEN_DEBUG
+    }
+
+}

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -50,6 +50,10 @@ impl<'a> DataGenOutput<'a> {
         self.writer.write_all(bytes).map(|()| bytes.len() as u64)
     }
 
+    pub fn write_str(&mut self, value: &str) -> io::Result<u64> {
+        self.write_bytes(value.as_bytes())
+    }
+
     pub fn write_string<D: Display + ?Sized>(&mut self, value: &D) -> io::Result<u64> {
         let start = self.writer.get_num_bytes_written();
         self.writer


### PR DESCRIPTION
Allow different modules to each define functions with the same signature, and allow module names at the call site to disambiguate. Also added in some much improved error handling. Compile errors now render the source location, and runtime errors can optionally print stack traces.